### PR TITLE
Use sphinx-version-warning to show a banner in 'latest'

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -53,6 +53,11 @@ def generate_patched_readme(_):
 nitpicky = True
 nitpick_ignore = [('py:class', 'callable')]
 
+versionwarning_messages = {
+    'latest': 'You are reading the documentation for an unreleased development version. {newest} is the most recent released version.',
+}
+versionwarning_body_selector = 'div[itemprop="articleBody"]'
+
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.doctest',
@@ -69,6 +74,7 @@ extensions = [
     'nbsphinx',
     'sphinx.ext.inheritance_diagram',
     'sphinxcontrib.bibtex',
+    'versionwarning.extension',
 ]
 if os.getenv('SPELLCHECK'):
     extensions += ('sphinxcontrib.spelling',)

--- a/docs/rtd_environment.yml
+++ b/docs/rtd_environment.yml
@@ -12,3 +12,4 @@ dependencies:
     - sphinxcontrib-bibtex
     - nbsphinx<0.4
     - gitpython
+    - sphinx-version-warning


### PR DESCRIPTION
This PR includes the minimal configuration to show a banner in the `latest` version of the documentation using [sphinx-version-warning](https://github.com/humitos/sphinx-version-warning/) extension.

See https://twitter.com/goerz/status/1158530631367872512 for references.

Happy hacking!