### PR TITLE
Add support for parametrized pulses

### DIFF
--- a/docs/notebooks/01_example_simple_state_to_state_parametrization.ipynb
+++ b/docs/notebooks/01_example_simple_state_to_state_parametrization.ipynb
@@ -1,0 +1,1049 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Optimization of a State-to-State Transfer in a Two-Level-System"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-06-05T03:30:31.973885Z",
+     "start_time": "2021-06-05T03:30:30.498419Z"
+    },
+    "attributes": {
+     "classes": [],
+     "id": "",
+     "n": "1"
+    },
+    "execution": {
+     "iopub.execute_input": "2021-01-13T19:19:44.665929Z",
+     "iopub.status.busy": "2021-01-13T19:19:44.664641Z",
+     "iopub.status.idle": "2021-01-13T19:19:46.393975Z",
+     "shell.execute_reply": "2021-01-13T19:19:46.394993Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Python implementation: CPython\n",
+      "Python version       : 3.8.1\n",
+      "IPython version      : 7.24.1\n",
+      "\n",
+      "qutip     : 4.6.1\n",
+      "json      : 2.0.9\n",
+      "krotov    : 1.2.1+dev\n",
+      "matplotlib: 3.4.2\n",
+      "numpy     : 1.20.3\n",
+      "scipy     : 1.6.3\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
+    "%load_ext watermark\n",
+    "import qutip\n",
+    "import numpy as np\n",
+    "import scipy\n",
+    "import matplotlib\n",
+    "import matplotlib.pylab as plt\n",
+    "import krotov\n",
+    "%watermark -v --iversions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-06-05T03:30:32.014876Z",
+     "start_time": "2021-06-05T03:30:31.978525Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "$\\newcommand{tr}[0]{\\operatorname{tr}}\n",
+    "\\newcommand{diag}[0]{\\operatorname{diag}}\n",
+    "\\newcommand{abs}[0]{\\operatorname{abs}}\n",
+    "\\newcommand{pop}[0]{\\operatorname{pop}}\n",
+    "\\newcommand{aux}[0]{\\text{aux}}\n",
+    "\\newcommand{opt}[0]{\\text{opt}}\n",
+    "\\newcommand{tgt}[0]{\\text{tgt}}\n",
+    "\\newcommand{init}[0]{\\text{init}}\n",
+    "\\newcommand{lab}[0]{\\text{lab}}\n",
+    "\\newcommand{rwa}[0]{\\text{rwa}}\n",
+    "\\newcommand{bra}[1]{\\langle#1\\vert}\n",
+    "\\newcommand{ket}[1]{\\vert#1\\rangle}\n",
+    "\\newcommand{Bra}[1]{\\left\\langle#1\\right\\vert}\n",
+    "\\newcommand{Ket}[1]{\\left\\vert#1\\right\\rangle}\n",
+    "\\newcommand{Braket}[2]{\\left\\langle #1\\vphantom{#2}\\mid{#2}\\vphantom{#1}\\right\\rangle}\n",
+    "\\newcommand{op}[1]{\\hat{#1}}\n",
+    "\\newcommand{Op}[1]{\\hat{#1}}\n",
+    "\\newcommand{dd}[0]{\\,\\text{d}}\n",
+    "\\newcommand{Liouville}[0]{\\mathcal{L}}\n",
+    "\\newcommand{DynMap}[0]{\\mathcal{E}}\n",
+    "\\newcommand{identity}[0]{\\mathbf{1}}\n",
+    "\\newcommand{Norm}[1]{\\lVert#1\\rVert}\n",
+    "\\newcommand{Abs}[1]{\\left\\vert#1\\right\\vert}\n",
+    "\\newcommand{avg}[1]{\\langle#1\\rangle}\n",
+    "\\newcommand{Avg}[1]{\\left\\langle#1\\right\\rangle}\n",
+    "\\newcommand{AbsSq}[1]{\\left\\vert#1\\right\\vert^2}\n",
+    "\\newcommand{Re}[0]{\\operatorname{Re}}\n",
+    "\\newcommand{Im}[0]{\\operatorname{Im}}$\n",
+    "\n",
+    "This first example illustrates the basic use of the `krotov` package by solving\n",
+    "a simple canonical optimization problem: the transfer of population in a two\n",
+    "level system."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Two-level-Hamiltonian"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We consider the Hamiltonian $\\op{H}_{0} = - \\frac{\\omega}{2} \\op{\\sigma}_{z}$, representing\n",
+    "a simple qubit with energy level splitting $\\omega$ in the basis\n",
+    "$\\{\\ket{0},\\ket{1}\\}$. The control field $\\epsilon(t)$ is assumed to couple via\n",
+    "the Hamiltonian $\\op{H}_{1}(t) = \\epsilon(t) \\op{\\sigma}_{x}$ to the qubit,\n",
+    "i.e., the control field effectively drives transitions between both qubit\n",
+    "states."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-06-05T03:30:32.081295Z",
+     "start_time": "2021-06-05T03:30:32.019969Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from krotov.parametrization import ParametrizedFunction, SquareParametrization"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-06-05T03:30:32.136097Z",
+     "start_time": "2021-06-05T03:30:32.094558Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2021-01-13T19:19:46.410246Z",
+     "iopub.status.busy": "2021-01-13T19:19:46.408668Z",
+     "iopub.status.idle": "2021-01-13T19:19:46.413830Z",
+     "shell.execute_reply": "2021-01-13T19:19:46.415108Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def hamiltonian(omega=1.0, ampl0=0.2):\n",
+    "    \"\"\"Two-level-system Hamiltonian\n",
+    "\n",
+    "    Args:\n",
+    "        omega (float): energy separation of the qubit levels\n",
+    "        ampl0 (float): constant amplitude of the driving field\n",
+    "    \"\"\"\n",
+    "    H0 = -0.5 * omega * qutip.operators.sigmaz()\n",
+    "    H1 = qutip.operators.sigmax()\n",
+    "\n",
+    "    def guess_control(t, args):\n",
+    "        return ampl0 * krotov.shapes.flattop(\n",
+    "            t, t_start=0, t_stop=5, t_rise=0.3, func=\"blackman\"\n",
+    "        )\n",
+    "\n",
+    "    return [H0, [H1, ParametrizedFunction(guess_control, SquareParametrization())]]\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-06-05T03:30:32.193076Z",
+     "start_time": "2021-06-05T03:30:32.139501Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2021-01-13T19:19:46.427358Z",
+     "iopub.status.busy": "2021-01-13T19:19:46.425505Z",
+     "iopub.status.idle": "2021-01-13T19:19:46.430133Z",
+     "shell.execute_reply": "2021-01-13T19:19:46.430876Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "H = hamiltonian()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The control field here switches on from zero at $t=0$ to it's maximum amplitude\n",
+    "0.2 within the time period 0.3 (the switch-on shape is half a [Blackman pulse](https://en.wikipedia.org/wiki/Window_function#Blackman_window)).\n",
+    "It switches off again in the time period 0.3 before the\n",
+    "final time $T=5$). We use a time grid with 500 time steps between 0 and $T$:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-06-05T03:30:32.227201Z",
+     "start_time": "2021-06-05T03:30:32.195554Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2021-01-13T19:19:46.442452Z",
+     "iopub.status.busy": "2021-01-13T19:19:46.441005Z",
+     "iopub.status.idle": "2021-01-13T19:19:46.445245Z",
+     "shell.execute_reply": "2021-01-13T19:19:46.446218Z"
+    },
+    "lines_to_next_cell": 2
+   },
+   "outputs": [],
+   "source": [
+    "tlist = np.linspace(0, 5, 500)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-06-05T03:30:32.269327Z",
+     "start_time": "2021-06-05T03:30:32.229778Z"
+    },
+    "attributes": {
+     "classes": [],
+     "id": "",
+     "n": "10"
+    },
+    "execution": {
+     "iopub.execute_input": "2021-01-13T19:19:46.460637Z",
+     "iopub.status.busy": "2021-01-13T19:19:46.459158Z",
+     "iopub.status.idle": "2021-01-13T19:19:46.466454Z",
+     "shell.execute_reply": "2021-01-13T19:19:46.468083Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def plot_pulse(pulse, tlist):\n",
+    "    fig, ax = plt.subplots()\n",
+    "    if callable(pulse):\n",
+    "        pulse = np.array([pulse(t, args=None) for t in tlist])\n",
+    "    ax.plot(tlist, pulse)\n",
+    "    ax.set_xlabel('time')\n",
+    "    ax.set_ylabel('pulse amplitude')\n",
+    "    plt.show(fig)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-06-05T03:30:32.526924Z",
+     "start_time": "2021-06-05T03:30:32.283894Z"
+    },
+    "attributes": {
+     "classes": [],
+     "id": "",
+     "n": "11"
+    },
+    "execution": {
+     "iopub.execute_input": "2021-01-13T19:19:46.517368Z",
+     "iopub.status.busy": "2021-01-13T19:19:46.515875Z",
+     "iopub.status.idle": "2021-01-13T19:19:46.829993Z",
+     "shell.execute_reply": "2021-01-13T19:19:46.830896Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAY4AAAEGCAYAAABy53LJAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAAAmPElEQVR4nO3de5SddX3v8fdn7slckkkypJgQEjReUrSgA7hqxdYLhh5LOBUUvME5HGmPcuo5LttiL2ipdtXTs7TLLtqKFRWrRcRjTTWWchS1tgIZIAIBozEEyKXknrkkc9mZ7/ljPztsJzOZvWf2s5+9Zz6vtfaa/fyey/4+RvZ3/y7P76eIwMzMrFQNWQdgZmb1xYnDzMzK4sRhZmZlceIwM7OyOHGYmVlZmrIOoBqWLVsWq1evzjoMM7O68uCDDx6IiJ6J5fMicaxevZq+vr6swzAzqyuSnpqs3E1VZmZWFicOMzMrixOHmZmVxYnDzMzK4sRhZmZlSTVxSFovaZuk7ZJunGT/+yU9LukRSd+WdHbRvmsk/TR5XVNU/gpJjybX/KQkpXkPZmb281JLHJIagVuAS4F1wNWS1k047GGgNyJeBtwF/O/k3CXAh4CLgAuBD0nqTs75G+DdwNrktT6tezAzs1Ol+RzHhcD2iNgBIOkOYAPweOGAiLi36Pj7gHck798I3BMRh5Jz7wHWS/ou0BUR9yXltwOXA99K8T5mbf/ACF/e/DSjufGsQzGzOnD+qm5+7cVnZB3GlNJMHCuAZ4q2d5GvQUzlOp5LAJOduyJ57Zqk/BSSrgeuB1i1alU5cVdURPBbX+jjoaeP4EY1M5tOBEhwx7tfyUXnLM06nEnVxJPjkt4B9AKvqdQ1I+JW4FaA3t7ezFar2nFgiIeePsKHf2Md175qTVZhmFmdODaa46I/+zb/uGV3zSaONDvHdwNnFW2vTMp+jqTXA38IXBYRI9Ocuzt5f9pr1pIHnjwEwMUvPGW6FzOzUyxsaeKC1Uu4P/nuqEVpJo7NwFpJayS1AFcBG4sPkHQ+8CnySWNf0a67gUskdSed4pcAd0fEXqBf0iuT0VTvAr6e4j3M2oNPHWZpewtrlrVnHYqZ1Yne1d3s2D/EkWOjWYcyqdQSR0TkgBvIJ4EngDsjYqukmyVdlhz2F0AH8BVJWyRtTM49BPwp+eSzGbi50FEOvAf4O2A78DNqvGN8x/5B1i7vwKOGzaxULzyjE8g3ddeiVPs4ImITsGlC2U1F719/mnNvA26bpLwPOLeCYaZq58FjXLJuedZhmFkdWZ20UOw8MMTLV3VPc3T1+cnxFB09PsahodGT/ycwMyvFqiULaVD+h2ctcuJI0VMH89XM1UsXZhyJmdWTlqYGVnQvYGeNNlU5caRoz5FhAFZ2O3GYWXlWLF7A3qPHsw5jUk4cKXq2P584zuhqzTgSM6s3y7va+I/kO6TWOHGk6Nn+YZoaxLJ2Jw4zK88vdLXxbP8IEZk9vzwlJ44U/Uf/MGd0ttLQ4KG4Zlae5V1tjObGOXJsLOtQTuHEkaJ9/SMsX9SWdRhmVoeWd+W/O2qxucqJI0XP9g+zvNOJw8zK9wuL8k3cThzzzIHBEZZ1tmQdhpnVoSVJ3+jhodqbdsSJIyW5E+McOT7GUneMm9kMLFmY/9F5yIlj/jh8bIwIWNrhGoeZla+zrYkG4c7x+aTwK2FJuxOHmZWvoUF0L2zhUA3OkOvEkZKDg/mlRdxUZWYz1d3eUpNTqztxpORgUuNwU5WZzVT3wmb3ccwnbqoys9nqXtjC4SH3ccwbhcSxeEFzxpGYWb3qXtjC4fnWVCVpvaRtkrZLunGS/RdLekhSTtIVReW/lqwIWHgNS7o82fc5SU8W7TsvzXuYqaPHx+hsbaKp0bnZzGamuz2fOGptvqrUVgCU1AjcArwB2AVslrQxIh4vOuxp4FrgA8XnRsS9wHnJdZaQXyb2X4oO+d2IuCut2Cuh//gYXa5tmNksLGlvZuxEMDR6go7WVBdsLUuaP4cvBLZHxI6IGAXuADYUHxAROyPiEWD8NNe5AvhWRNTmUlhTOHp8jEVOHGY2C4uThwBr7enxNBPHCuCZou1dSVm5rgL+YULZRyU9IukTkiYd7yrpekl9kvr2798/g4+dHScOM5utwtPjtdbPUdMN8JLOBF4K3F1U/EHgxcAFwBLg9yc7NyJujYjeiOjt6elJPdaJnDjMbLa62/PfIbU2JDfNxLEbOKtoe2VSVo63AF+LiJPj0SJib+SNAJ8l3yRWc5w4zGy2uudhjWMzsFbSGkkt5JucNpZ5jauZ0EyV1EKQJOBy4LHZh1p5R4+PsWihE4eZzVzhObBae5YjtcQRETngBvLNTE8Ad0bEVkk3S7oMQNIFknYBVwKfkrS1cL6k1eRrLN+bcOkvSnoUeBRYBnwkrXuYqeGxE4zkxl3jMLNZ6WprpkG1V+NIdXxXRGwCNk0ou6no/WbyTViTnbuTSTrTI+K1lY2y8vqP538deDiumc1GQ4PoaG1iYDiXdSg/p6Y7x+vV0SRxuMZhZrPVtaD55I/RWuHEkQInDjOrlM62Zvpd45j7nDjMrFI625roH3aNY85z4jCzSulqa3Yfx3zgxGFmldLV1sSAaxxzXyFxdLXVzqRkZlafOtua3Dk+Hxw9PkaHp1Q3swroWtDM4EiO8fHamVrd32wp8HQjZlYpnW1NjAcMjdZOP4cTRwr6j+fodDOVmVVAZ1v+R2gtdZA7caRgcGSMrjbXOMxs9rqcOOaHwZEcHa5xmFkFFFovaulZDieOFAwO52pqmUczq1+FxFFLQ3KdOFIwOHLCNQ4zq4jCZKluqprjBkfG6HSNw8wq4GRTVQ09y+HEUWFjJ8YZHht3U5WZVUShc7yWJjp04qiwoZH8P66bqsysEtqaG2lpbJg/neOS1kvaJmm7pBsn2X+xpIck5SRdMWHfCUlbktfGovI1ku5PrvnlZFnamlFoh3SNw8wqpbOtthZzSi1xSGoEbgEuBdYBV0taN+Gwp4FrgS9NconjEXFe8rqsqPxjwCci4gXAYeC6igc/C4NJjcMPAJpZpXQtqK0ZctOscVwIbI+IHRExCtwBbCg+ICJ2RsQjwHgpF5Qk4LXAXUnR54HLKxZxBRQSR0erHwA0s8qotYkO00wcK4BnirZ3Mcka4qfRJqlP0n2SLk/KlgJHIqKQeqe8pqTrk/P79u/fX2boMzc47D4OM6usjtamkz9Ka0Etd46fHRG9wNuAv5T0/HJOjohbI6I3Inp7enrSiXASAyPu4zCzyupobTo58KYWpJk4dgNnFW2vTMpKEhG7k787gO8C5wMHgcWSCt/KZV2zGgbdOW5mFdbROk86x4HNwNpkFFQLcBWwcZpzAJDULak1eb8MeBXweEQEcC9QGIF1DfD1ikc+C4Mj+XZIN1WZWaW0tzbNj2nVk36IG4C7gSeAOyNiq6SbJV0GIOkCSbuAK4FPSdqanP4SoE/Sj8gnij+PiMeTfb8PvF/SdvJ9Hp9J6x5mYnA4hwQLmxuzDsXM5oiOtnxTVf63c/ZS/VkcEZuATRPKbip6v5l8c9PE8/4deOkU19xBfsRWTRoYydHR0kRDg7IOxczmiI7WJsZOBCO5cdpq4EdpLXeO16XBYU+pbmaV1d6STxa10kHuxFFhgyOeUt3MKqsjma9qaORExpHkOXFUmBdxMrNK62jN1zgGRmrjIUAnjgob8CJOZlZh7cl3imscc9TgSM7zVJlZRXWcTBx10sch6YWSvi3psWT7ZZL+KP3Q6pOXjTWzSit8pwzUS+IAPg18EBgDSCYlvCrNoOpZvnPcExyaWeUU+k3rpsYBLIyIByaU1Ub0NWZ8PNw5bmYV115vTVXAgWSCwQBIFlzam2pUdaowJYDXGzezSmpvSZqqamS+qlK+4d4L3Aq8WNJu4EngHalGVacGvWysmaWgsUEsbGmsmRrHtN9wyRQfr5fUDjRExED6YdUnz4xrZmmppYkOp/yGk/T+KcoBiIiPpxRT3RpwjcPMUlJLU6uf7huuM/n7IuACnpsS/TeAiZ3lhmscZpaeWlrMacpvuIj4EwBJ3wdeXmiikvRh4JtVia7ODHr1PzNLSXtrY109Ob4cGC3aHk3KbAInDjNLS0drU109AHg78ICkDye1jfuBz5dycUnrJW2TtF3SjZPsv1jSQ5JyyTDfQvl5kn4oaaukRyS9tWjf5yQ9KWlL8jqvlFiqodBU5SlHzKzS6qKpqiAiPirpW8Crk6L/EhEPT3eepEbgFuANwC5gs6SNRSv5ATwNXAt8YMLpx4B3RcRPJT0PeFDS3RFxJNn/uxFx13QxVFuhxtHuGoeZVVh7PSUOSauAA8DXissi4ulpTr0Q2J4M50XSHcAG4GTiiIidyb7x4hMj4idF7/dI2gf0AEemizdLgyM52pobaG703JFmVln11lT1TeAbyevbwA7gWyWctwJ4pmh7V1JWFkkXAi3Az4qKP5o0YX1CUusU510vqU9S3/79+8v92BnxlOpmlpaO1iZGc+OMnRif/uCUTZs4IuKlEfGy5LWWfE3ih+mHBpLOBL5Avnms8L/WB4EXkx8ivAT4/cnOjYhbI6I3Inp7enqqES5DIzk3U5lZKmppvqqy21Qi4iHgohIO3Q2cVbS9MikriaQu8rWdP4yI+4o+f2/kjQCfJZ/IasKQl401s5QUHiyuhYcAS+njKH6CvAF4ObCnhGtvBtZKWkM+YVwFvK2UoCS1kO9TuX1iJ7ikMyNir/KPsF8OPFbKNathwDUOM0vJycWcamDakVJqHJ1Fr1bytYAN050UETngBuBu4AngzojYKulmSZcBSLpA0i7gSuBTkrYmp78FuBi4dpJht1+U9CjwKLAM+Ehpt5o+1zjMLC211FRVyrfc4xHxleICSVcCX5ni+JMiYhOwaULZTUXvN5Nvwpp43t8Dfz/FNV9bQsyZcOIws7ScXAWwBpqqSqlxfLDEsnlv0E1VZpaS59Ydz37akdPNjnsp8OvACkmfLNrVhVcAnFR+2djGrMMwszmoPfluqfWmqj1AH3AZ8GBR+QDwv9IMqh7lTowzPDbu9cbNLBWdyXdLLTwEeLrZcX8E/EjSF5OObjuNQvWx3TUOM0tBXdQ4JN0ZEW8BHpYUE/dHxMtSjazODI56gkMzS09TYwOtTQ21nTiA9yV/31SNQOrdkCc4NLOUdbbVxnxVp2uq2pv8fap64dSvwhA5Jw4zS0utzJB7uqaqAaC4iUrJtoCIiK6UY6srhX/MTicOM0tJe0uNJ46I6Jxqn53KTVVmlraOtqaaeACwpG85SS8HfoV8jeMHpSzkNN8MeNlYM0tZR2sT+waGsw5j+ifHJd1EfqnYpeTnhvqcpD9KO7B6M+TEYWYpyy8fW8NPjhd5O/BLETEMIOnPgS3U0OSCtcBNVWaWtvbW2miqKmWuqj1AW9F2K2WsqzFfDIzkaGlsoKXJy8aaWTo6Whtru3O8yFFgq6R7yPdxvAF4oDB/VUT8Torx1Y2hkdzJhVbMzNLQ0drM8bETnBgPGhuUWRylfNN9LXkVfDedUOrb0MgJTzdiZqkqfMcMjuRYtCC7efGmTRwR8flqBFLvBoZznuDQzFLVUbSYU5aJo5RRVW+S9LCkQ5L6JQ1I6i/l4pLWS9omabukGyfZf7GkhyTlJF0xYd81kn6avK4pKn+FpEeTa34yWUI2c0OeUt3MUlZoDh/MuJ+jlJ7cvwSuAZZGRFdEdJby1LikRuAW4FJgHXC1pHUTDnsauBb40oRzlwAfAi4CLgQ+JKk72f03wLuBtclrfQn3kLqhUS/iZGbpKtQ46iFxPAM8FhGnzJA7jQuB7RGxIyJGgTuYsFZ5ROyMiEeA8QnnvhG4JyIORcRh4B5gvaQzga6IuC+J53bg8jLjSsXgsJeNNbN0FWbfHsx4SG4p33S/B2yS9D1gpFAYER+f5rwV5JNOwS7yNYhSTHbuiuS1a5LyU0i6HrgeYNWqVSV+7MwNer1xM0tZex3VOD4KHCP/LEdn0aumRcStEdEbEb09PT2pf57XGzeztJ1sqqqDGsfzIuLcGVx7N3BW0fZKSn9wcDfwqxPO/W5SvnKG10zN+HhwbPSEaxxmlqpaWT62lBrHJkmXzODam4G1ktZIagGuAjaWeO7dwCWSupNO8UuAu5M1QvolvTIZTfUu4OsziK2ihkY9T5WZpe/kcxwZ1zhKSRz/HfhnScfLGY6brFN+A/kk8ARwZ0RslXSzpMsAJF0gaRdwJfApSVuTcw8Bf0o++WwGbk7KAN4D/B2wHfgZ8K0y7jcVg56nysyqoKmxgQXNjQyOjGUbx3QHzGZdjojYBGyaUHZT0fvN/HzTU/FxtwG3TVLeB8yk6Sw1J2fG9ZQjZpayjrYmBjOeIbfU9Ti6yT8zcXKyw4j4flpB1ZvCP6IfADSztHW2NmU+qmraxCHpvwHvI18z2AK8Evgh8NpUI6sjhfZGTzliZmnraGticDjbpqpS+jjeB1wAPBURvwacDxxJM6h681wfh2scZpaujhqocZSSOIaLFnFqjYgfAy9KN6z64tX/zKxaOmpgMadSvul2SVoM/CNwj6TDwFNpBlVvBp04zKxKaqHGUcqoqv+cvP2wpHuBRcA/pxpVnfFwXDOrlvyoqhpPHMUi4ntpBVLPhkZyNDWIVi8ba2Yp62htYnA4R0SQ1aoS/qargMFk2dgaWRrEzOawjrYmcuPBSG7ipOLV48RRAYMjOdpb3ExlZunrTJrEs+wgLylxSDpb0uuT9wsk1fzsuNU05CnVzaxKamEVwFKWjn03cBfwqaRoJfkRVpYoNFWZmaWt8KBxlhMdllLjeC/wKqAfICJ+CpyRZlD1ZnDkhEdUmVlVFFo3BjKc6LCUxDGSLP0KgKQmoNxlZOe0oZHcyXZHM7M01cLysaUkju9J+gNggaQ3AF8B/indsOrL4HDO042YWVUUahyFdYCyUEriuBHYDzwK/Bb5adL/KM2g6s2Ql401syppr4HlY0t5cnwc+DTwaUlLgJUR4aaqxPh4MDiao7PNM+OaWfoKTVVZLh9byqiq70rqSpLGg+QTyCdKubik9ZK2Sdou6cZJ9rdK+nKy/35Jq5Pyt0vaUvQal3ReUTzbivZl2lE/OJojAro8qsrMqqC1qYGmBtV8H8eiiOgHfhO4PSIuAl433UmSGoFbgEuBdcDVktZNOOw64HBEvAD4BPAxgIj4YkScFxHnAe8EnoyILUXnvb2wPyL2lXAPqSk8hNPpxGFmVSAp8/mqSkkcTZLOBN4CfKOMa18IbI+IHcmorDuADROO2QB8Pnl/F/A6nTpvx9XJuTVpIFlQxU1VZlYthfmqslJK4rgZuJt8Etgs6RzgpyWctwJ4pmh7V1I26TERkQOOAksnHPNW4B8mlH02aab640kSDQCSrpfUJ6lv//79JYQ7M65xmFm1dbQ21XYfR0R8JSJeFhHvSbZ3RMSb0w8NJF0EHIuIx4qK3x4RLwVenbzeOdm5EXFrRPRGRG9PT09qMbrGYWbV1tmWbY1jyp/Jkv6K0zzoFxG/M821dwNnFW2vTMomO2ZX8mDhIuBg0f6rmFDbiIjdyd8BSV8i3yR2+zSxpKb/uGscZlZdHa1NHBgcnf7AlJzu265vltfeDKyVtIZ8grgKeNuEYzYC1wA/BK4AvlMY6iupgXy/yqsLByfJZXFEHJDUDLwJ+H+zjHNWnqtxOHGYWXV0tDWz8+CxzD5/ym+7iPj8VPtKERE5STeQ7x9pBG6LiK2Sbgb6ImIj8BngC5K2A4fIJ5eCi4FnImJHUVkrcHeSNBrJJ41PzybO2epPqotdbqoysyrpaG3MdFr1aX8mJ8vFntJkFRGvne7ciNhE/knz4rKbit4PA1dOce53gVdOKBsCXjHd51bTwHCO5kav/mdm1ZNfdzy7SQ5LaV/5QNH7NuDNQLYL3taQgeExOtuavfqfmVVNR2szw2PjjJ0Yp7mx+j9aS5ly5MEJRf8m6YGU4qk7A8M592+YWVUtWvDcKoBL2luq/vmlNFUtKdpsIN9UtCi1iOpMvsbhxGFm1dO1IN+n2n98rDYTB/n5qQIQ+SaqJ8lPFWIkNY5Wd4ybWfUUBuMcPZ5NP0cpTVVrqhFIvRoYznH20oVZh2Fm88jJGsdwjSYOSW3Ae4BfIV/z+Ffgb5MRUfNeoXPczKxaFp1sqspmnFIpTVW3AwPAXyXbbwO+wBTDaOcbd46bWbV1JZ3jNVvjAM6NiOLp0O+V9HhaAdWTE+PBwEjOa3GYWVUV+jj6M+rjKGUA8EOSTj6Il0w8ONvpSOaEwnz4bqoys2pa2NJIY4Nqt3Oc/PDbf5f0dLK9Ctgm6VEgIuJlqUVX4zxPlZllQRJdbU013VS1PvUo6tRza3G4xmFm1bVoQXPtdo5HxFPVCKQeHTmWz/bdC504zKy6uhY0Z1bj8Mx8s1BoXyyMqTYzq5autuaa7hy3KRw9nl9IZbFrHGZWZV0LmjLrHHfimIVCU9XihdWfK8bM5rdFC5pPrgdUbakmDknrJW2TtF3SjZPsb5X05WT//ZJWJ+WrJR2XtCV5/W3ROa+Q9GhyzieV4XzmR4+P0dQg2lsaswrBzOapOdlUJakRuAW4FFgHXC1p3YTDrgMOR8QLgE8AHyva97OIOC95/XZR+d8A7wbWJq/MRn0dOT7GogVei8PMqq9rQTMjuXGGx05U/bPTrHFcCGyPiB0RMQrcAWyYcMwGoLBE7V3A605Xg5B0JtAVEfcla5PfDlxe8chLdPTYGIvcv2FmGSjMWJHFErJpJo4VwDNF27uSskmPiYgccBRYmuxbI+lhSd+T9Oqi43dNc00AJF0vqU9S3/79+2d3J1M4cnyUxR5RZWYZKIzmzKKDvFY7x/cCqyLifOD9wJckdZVzgYi4NSJ6I6K3p6cnlSCPHh9zx7iZZWKuJo7dwFlF2yuTskmPkdREfmXBgxExEhEH4eTStT8DXpgcv3Kaa1bNkWNjJ6c3NjOrpu7kR2vhsYBqSjNxbAbWSlojqQW4Ctg44ZiNwDXJ+yuA70RESOpJOteRdA75TvAdEbEX6Jf0yqQv5F3A11O8h9M66sRhZhkpzFhxaKj6NY7UZueLiJykG4C7gUbgtojYKulmoC8iNgKfAb4gaTtwiHxyAbgYuFnSGDAO/HZEHEr2vQf4HLAA+FbyqrrciXEGRnJ++M/MMtGdrDV+eKj6NY5Up3WNiE3ApgllNxW9H2aSBaEi4qvAV6e4Zh9wbmUjLV/hwRt3jptZFjpbm2hqEIePza2mqjntSPKP5eG4ZpYFSSxe2OLEUU+OJCMZFi/wqCozy8aS9mYOZdBU5cQxQ4UhcK5xmFlWuhe2cPjY3BqOO6cdLUxw6D4OM8tI98KWTDrHnThmqFA97PYDgGaWke5293HUlYNDIzQ1yM9xmFlmlrQ3c/jYGPmp+6rHiWOGDgyMsqS9hYYGz4xrZtnoXtjCifGo+rocThwzdHBohKUdrVmHYWbzWKGpvNr9HE4cM3RgcJRlHe7fMLPsLCk8PV7lfg4njhk6ODTC0nYnDjPLTmHKIyeOOnFwcNRNVWaWqUKNo9oTHTpxzMCx0RzHRk+wzInDzDLUfTJxjFT1c504ZuDgYL5auNR9HGaWoc7WJtqaG9g/4MRR8w4M5v+R3DluZlmSxBmdbTzb78RR807WONrdVGVm2Vre1cq+geGqfqYTxwwUahxuqjKzrJ3R2ca+uVTjkLRe0jZJ2yXdOMn+VklfTvbfL2l1Uv4GSQ9KejT5+9qic76bXHNL8jojzXuYzMHkYRt3jptZ1no6W9lX5T6O1FYATNYMvwV4A7AL2CxpY0Q8XnTYdcDhiHiBpKuAjwFvBQ4AvxEReySdS3752RVF5709WQkwEwcGR+hobaKtuTGrEMzMAFje1cbgSI6hkRztraku6npSmjWOC4HtEbEjIkaBO4ANE47ZAHw+eX8X8DpJioiHI2JPUr4VWCCpZn7e7+sfoaezZsIxs3nsjOS7qJq1jjQTxwrgmaLtXfx8reHnjomIHHAUWDrhmDcDD0VE8f8qn02aqf5Y0qSzDEq6XlKfpL79+/fP5j5OsfvIcZ63uK2i1zQzm4nlXfnvomf7q9dBXtOd45J+kXzz1W8VFb89Il4KvDp5vXOycyPi1ojojYjenp6eisa19+hxzly0oKLXNDObiTO65laNYzdwVtH2yqRs0mMkNQGLgIPJ9krga8C7IuJnhRMiYnfydwD4EvkmsaoZzY2zb2CE5y124jCz7C3vzNc49s2RGsdmYK2kNZJagKuAjROO2Qhck7y/AvhORISkxcA3gRsj4t8KB0tqkrQsed8MvAl4LMV7OMWz/cNEwAo3VZlZDeha0ERLU8PcqHEkfRY3kB8R9QRwZ0RslXSzpMuSwz4DLJW0HXg/UBiyewPwAuCmCcNuW4G7JT0CbCFfY/l0WvcwmT1HjgO4xmFmNUESy7ta+Y+j1atxpDp2KyI2AZsmlN1U9H4YuHKS8z4CfGSKy76ikjGWa8/RfOJwH4eZ1YqVixey6/Cxqn1eTXeO16I9R/JZ3aOqzKxWnL10IU8ddOKoWXuOHKd7YTMLW6rzoI2Z2XRWLV3IwaFRBkeqs/a4E0eZ9hzxUFwzqy1nL2kH4KmDQ1X5PCeOMu05MuyOcTOrKWcvXQjA01VqrnLiKMP4eLDz4BBrli3MOhQzs5MKiWOnE0ft2X3kOCO5cc7p6cg6FDOzkzrbmlnS3sLTh9xUVXN2HMj/o5yzrD3jSMzMfl41R1Y5cZRhx/5BANc4zKzmrF7azs4DrnHUnCf29rO0vcVrjZtZzVm7vIM9R4c5enws9c9y4ijDE3sHeMmZXUwxk7uZWWZecmYXAD/e25/6ZzlxlGjsxDjbnh3gJWd2Zh2Kmdkp1iWJY+seJ46a8cTefkZz47x05eKsQzEzO8UZna0s72plyzNHUv8sJ44S9e08DMAFq7szjsTM7FSS6F29hAefOpz6ZzlxlOj+Jw+ysnuBpxsxs5p1wdnd7D5ynGcOpTss14mjBCO5E/zgpwd4zQsruwStmVklveZFZwDwnR/vS/VznDhK8K8/OcDQ6Ale95Izsg7FzGxKa5a1c05PO996bG+qn5Nq4pC0XtI2Sdsl3TjJ/lZJX0723y9pddG+Dybl2yS9sdRrpuFLDzxNT2crr17rGoeZ1bY3v3wl9+04xPZ9g6l9RmqJQ1IjcAtwKbAOuFrSugmHXQccjogXAJ8APpacu478GuW/CKwH/lpSY4nXrKjv/2Q/3/nxPt75yrNpbnQFzcxq21svOIuFLY189JuPc2I8UvmMNL8JLwS2R8SOiBgF7gA2TDhmA/D55P1dwOuUf7puA3BHRIxExJPA9uR6pVyzYv7ga4/yXz+3mef3tPPuV5+T1seYmVXMso5Wfu+NL+Lebft5/ce/x0+eHaj4Z6S5jN0K4Jmi7V3ARVMdExE5SUeBpUn5fRPOXZG8n+6aAEi6HrgeYNWqVTO6gZXdC7jml1fz2695PgtaGmd0DTOzarv2VWtYvLCFrz28mxUprB80Z9c/jYhbgVsBent7Z1Rfe8+vvqCiMZmZVcvl56/g8vNXTH/gDKTZVLUbOKtoe2VSNukxkpqARcDB05xbyjXNzCxFaSaOzcBaSWsktZDv7N444ZiNwDXJ+yuA70REJOVXJaOu1gBrgQdKvKaZmaUotaaqpM/iBuBuoBG4LSK2SroZ6IuIjcBngC9I2g4cIp8ISI67E3gcyAHvjYgTAJNdM617MDOzUyn/A39u6+3tjb6+vqzDMDOrK5IejIjeieV+MMHMzMrixGFmZmVx4jAzs7I4cZiZWVnmRee4pP3AUzM8fRlwoILh1APf8/zge577Znu/Z0fEKbO7zovEMRuS+iYbVTCX+Z7nB9/z3JfW/bqpyszMyuLEYWZmZXHimN6tWQeQAd/z/OB7nvtSuV/3cZiZWVlc4zAzs7I4cZiZWVmcOE5D0npJ2yRtl3Rj1vGkTdJtkvZJeizrWKpB0lmS7pX0uKStkt6XdUxpk9Qm6QFJP0ru+U+yjqlaJDVKeljSN7KOpRok7ZT0qKQtkio6y6v7OKYgqRH4CfAG8kvUbgaujojHMw0sRZIuBgaB2yPi3KzjSZukM4EzI+IhSZ3Ag8Dlc/zfWEB7RAxKagZ+ALwvIu6b5tS6J+n9QC/QFRFvyjqetEnaCfRGRMUfeHSNY2oXAtsjYkdEjAJ3ABsyjilVEfF98uuizAsRsTciHkreDwBP8Nza9nNS5A0mm83Ja87/epS0EvhPwN9lHctc4MQxtRXAM0Xbu5jjXyrzmaTVwPnA/RmHkrqkyWYLsA+4JyLm/D0Dfwn8HjCecRzVFMC/SHpQ0vWVvLATh817kjqArwL/MyL6s44nbRFxIiLOA1YCF0qa082Skt4E7IuIB7OOpcp+JSJeDlwKvDdpiq4IJ46p7QbOKtpemZTZHJK0838V+GJE/N+s46mmiDgC3AuszziUtL0KuCxp878DeK2kv882pPRFxO7k7z7ga+Sb3yvCiWNqm4G1ktZIaiG/HvrGjGOyCko6ij8DPBERH886nmqQ1CNpcfJ+AfnBHz/ONKiURcQHI2JlRKwm/9/xdyLiHRmHlSpJ7cmADyS1A5cAFRst6cQxhYjIATcAd5PvNL0zIrZmG1W6JP0D8EPgRZJ2Sbou65hS9irgneR/gW5JXr+edVApOxO4V9Ij5H8c3RMR82J46jyzHPiBpB8BDwDfjIh/rtTFPRzXzMzK4hqHmZmVxYnDzMzK4sRhZmZlceIwM7OyOHGYmVlZnDjMKkzSYknvSd4/T9JdWcdkVkkejmtWYcm8V9+YDzMM2/zUlHUAZnPQnwPPTyYS/Cnwkog4V9K1wOVAO7AW+D9AC/mHEEeAX4+IQ5KeD9wC9ADHgHdHxJx+utvqi5uqzCrvRuBnyUSCvzth37nAbwIXAB8FjkXE+eSf2H9XcsytwP+IiFcAHwD+uhpBm5XKNQ6z6ro3WftjQNJR4J+S8keBlyUz9f4y8JX8VFoAtFY/TLOpOXGYVddI0fvxou1x8v89NgBHktqKWU1yU5VZ5Q0AnTM5MVkP5ElJV0J+Bl9Jv1TJ4Mxmy4nDrMIi4iDwb5IeA/5iBpd4O3BdMrPpVub4ksVWfzwc18zMyuIah5mZlcWJw8zMyuLEYWZmZXHiMDOzsjhxmJlZWZw4zMysLE4cZmZWlv8PGfdd/VcJB5EAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plot_pulse(H[1][1], tlist)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Optimization target"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `krotov` package requires the goal of the optimization to be described by a\n",
+    "list of `Objective` instances. In this example, there is only a single\n",
+    "objective: the state-to-state transfer from initial state $\\ket{\\Psi_{\\init}} =\n",
+    "\\ket{0}$ to the target state $\\ket{\\Psi_{\\tgt}} = \\ket{1}$, under the dynamics\n",
+    "of the Hamiltonian $\\op{H}(t)$:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-06-05T03:30:32.576572Z",
+     "start_time": "2021-06-05T03:30:32.533460Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2021-01-13T19:19:46.841392Z",
+     "iopub.status.busy": "2021-01-13T19:19:46.840244Z",
+     "iopub.status.idle": "2021-01-13T19:19:46.844821Z",
+     "shell.execute_reply": "2021-01-13T19:19:46.845680Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[Objective[|Ψ₀(2)⟩ to |Ψ₁(2)⟩ via [H₀[2,2], [H₁[2,2], u₁(t)]]]]"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "objectives = [\n",
+    "    krotov.Objective(\n",
+    "        initial_state=qutip.ket(\"0\"), target=qutip.ket(\"1\"), H=H\n",
+    "    )\n",
+    "]\n",
+    "\n",
+    "objectives"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In addition, we would like to maintain the property of the control field to be\n",
+    "zero at $t=0$ and $t=T$, with a smooth switch-on and switch-off. We can define\n",
+    "an \"update shape\" $S(t) \\in [0, 1]$ for this purpose: Krotov's method will\n",
+    "update the field at each point in time proportionally to $S(t)$; wherever\n",
+    "$S(t)$ is zero, the optimization will not change the value of the control from\n",
+    "the original guess."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-06-05T03:30:32.637939Z",
+     "start_time": "2021-06-05T03:30:32.584917Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2021-01-13T19:19:46.853270Z",
+     "iopub.status.busy": "2021-01-13T19:19:46.849902Z",
+     "iopub.status.idle": "2021-01-13T19:19:46.857772Z",
+     "shell.execute_reply": "2021-01-13T19:19:46.858640Z"
+    },
+    "lines_to_next_cell": 2
+   },
+   "outputs": [],
+   "source": [
+    "def S(t):\n",
+    "    \"\"\"Shape function for the field update\"\"\"\n",
+    "    return krotov.shapes.flattop(\n",
+    "        t, t_start=0, t_stop=5, t_rise=0.3, t_fall=0.3, func='blackman'\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Beyond the shape, Krotov's method uses a parameter $\\lambda_a$  for each control\n",
+    "field that determines the overall magnitude of the respective field in each\n",
+    "iteration (the smaller $\\lambda_a$, the larger the update; specifically, the\n",
+    "update is proportional to $\\frac{S(t)}{\\lambda_a}$). Both the update-shape\n",
+    "$S(t)$ and the $\\lambda_a$ parameter must be passed to the optimization routine\n",
+    "as \"pulse options\":"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-06-05T03:30:32.677424Z",
+     "start_time": "2021-06-05T03:30:32.642559Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2021-01-13T19:19:46.864597Z",
+     "iopub.status.busy": "2021-01-13T19:19:46.863114Z",
+     "iopub.status.idle": "2021-01-13T19:19:46.869516Z",
+     "shell.execute_reply": "2021-01-13T19:19:46.871919Z"
+    },
+    "lines_to_next_cell": 0
+   },
+   "outputs": [],
+   "source": [
+    "pulse_options = {\n",
+    "    H[1][1]: dict(lambda_a=1, update_shape=S)\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Simulate dynamics under the guess field"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Before running the optimization procedure, we first simulate the dynamics under the\n",
+    "guess field $\\epsilon_{0}(t)$. The following solves equation of motion for the\n",
+    "defined objective, which contains the initial state $\\ket{\\Psi_{\\init}}$ and\n",
+    "the Hamiltonian $\\op{H}(t)$ defining its evolution. This delegates to QuTiP's\n",
+    "usual `mesolve` function."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We use the projectors $\\op{P}_0 = \\ket{0}\\bra{0}$ and $\\op{P}_1 = \\ket{1}\\bra{1}$ for calculating the population:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-06-05T03:30:32.718806Z",
+     "start_time": "2021-06-05T03:30:32.681405Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2021-01-13T19:19:46.879910Z",
+     "iopub.status.busy": "2021-01-13T19:19:46.877805Z",
+     "iopub.status.idle": "2021-01-13T19:19:46.883375Z",
+     "shell.execute_reply": "2021-01-13T19:19:46.884311Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "proj0 = qutip.ket2dm(qutip.ket(\"0\"))\n",
+    "proj1 = qutip.ket2dm(qutip.ket(\"1\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-06-05T03:30:32.885833Z",
+     "start_time": "2021-06-05T03:30:32.722169Z"
+    },
+    "attributes": {
+     "classes": [],
+     "id": "",
+     "n": "12"
+    },
+    "execution": {
+     "iopub.execute_input": "2021-01-13T19:19:47.061381Z",
+     "iopub.status.busy": "2021-01-13T19:19:47.059865Z",
+     "iopub.status.idle": "2021-01-13T19:19:47.063073Z",
+     "shell.execute_reply": "2021-01-13T19:19:47.063965Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "guess_dynamics = objectives[0].mesolve(tlist, e_ops=[proj0, proj1])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The plot of the population dynamics shows that the guess field does not transfer\n",
+    "the initial state $\\ket{\\Psi_{\\init}} = \\ket{0}$ to the desired target state\n",
+    "$\\ket{\\Psi_{\\tgt}} = \\ket{1}$ (so the optimization will have something to do)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-06-05T03:30:32.939335Z",
+     "start_time": "2021-06-05T03:30:32.890382Z"
+    },
+    "attributes": {
+     "classes": [],
+     "id": "",
+     "n": "13"
+    },
+    "execution": {
+     "iopub.execute_input": "2021-01-13T19:19:47.071001Z",
+     "iopub.status.busy": "2021-01-13T19:19:47.069947Z",
+     "iopub.status.idle": "2021-01-13T19:19:47.072686Z",
+     "shell.execute_reply": "2021-01-13T19:19:47.073366Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def plot_population(result):\n",
+    "    fig, ax = plt.subplots()\n",
+    "    ax.plot(result.times, result.expect[0], label='0')\n",
+    "    ax.plot(result.times, result.expect[1], label='1')\n",
+    "    ax.legend()\n",
+    "    ax.set_xlabel('time')\n",
+    "    ax.set_ylabel('population')\n",
+    "    plt.show(fig)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-06-05T03:30:33.484675Z",
+     "start_time": "2021-06-05T03:30:32.942579Z"
+    },
+    "attributes": {
+     "classes": [],
+     "id": "",
+     "n": "14"
+    },
+    "execution": {
+     "iopub.execute_input": "2021-01-13T19:19:47.104604Z",
+     "iopub.status.busy": "2021-01-13T19:19:47.103399Z",
+     "iopub.status.idle": "2021-01-13T19:19:47.271946Z",
+     "shell.execute_reply": "2021-01-13T19:19:47.272416Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYIAAAEGCAYAAABo25JHAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAAAkJklEQVR4nO3deXBd53nf8e+Dfd/BDQsBihQlipRECZRkK5HdNI5lxZESp46lJmkUyZGntVKnad1RpqkTue2Ms9ST1HbSqImbsVNbtZ3FtKzIUWupiWNRIiiK4iLRorlg4QYQIPYdT/94D4ALECQuSVxcAOf3mTlz7lnuuc8lcc9zzrsdc3dERCS+MtIdgIiIpJcSgYhIzCkRiIjEnBKBiEjMKRGIiMRcVroDuFpVVVXe0NCQ7jBERFaUffv2dbp79XzbVlwiaGhooLm5Od1hiIisKGZ26nLbVDQkIhJzSgQiIjGnRCAiEnNKBCIiMadEICIScylLBGb2RTM7b2aHLrPdzOy/mdkxM3vTzO5IVSwiInJ5qbwj+HPg/its/wCwJZqeAP44hbGIiMhlpKwfgbv/vZk1XGGXh4AveRgHe4+ZlZnZenc/k4p49p7s4h9+0AFmZBgYYZ6RYQBkmGHG9LbwevbcovdmZ2ZQmJNFQU5mNGVRkBteF+VmUZSbhZml4muIiCy6dHYoqwFaE5bbonWXJAIze4Jw10B9ff01fdjrp7r53EvHWIrHL2RlGGUFOVQUZod5QQ7lhdmUF+SwpjiXdaV5rCnJY11JHtXFuWRnqqpGRNJnRfQsdvdngGcAmpqarulU/rH33MDH3nPD1PGYdJh0x6M5zF6edGBqnznbRscnGRydYHB0nMHRCQZGxhkam2BgZIL+kTG6B8e4ODhK18Ao3YNjHO/sp7tljO6BUcYnZ4dvBpWFuawrzaWmLJ/6igLqoqm+ooDa8nxyszKv/R9PRGQB6UwE7UBdwnJttC7lzIxMg0yWtvhmctLpHhzlbO8w53qHOdc7wtme8Pps7zDHOwZ4+WgHI+OTCbHCupI86ioKaKwsZMvaIm5YU8Tm6iJqyvKni7ZERK5VOhPBbuBJM3sWuBvoSVX9wHKRkWFUFuVSWZTLLRtK593H3enoG6Gla3D2dGGQ//PWOf5380xpWn52JpuqC9kcJYYta4u4aV0J9RUFShAikrSUJQIz+yrwXqDKzNqA3wKyAdz9vwPPAw8Ax4BB4JdTFctKYmasKQl1CE0NFZds7x4Y5VhHP++c6+fY+X6OdfTTfLKbb75xenqfwpxMbl5fwrYNJWxbX8LN60vYuq6YvGwVMYnIpWylPby+qanJNfropQZGxjl2vp+3zvTy1plejpzp5a0zffSPjAOhNdQN1UVs21DCjppSbq8r45YNpeTnKDmIxIGZ7XP3pvm2rYjKYllYYW4Wt9WVcVtd2fS6yUmnrXuII2d6OHK6lyNn+njtRNf03UNmhnHj2mJuryvl1toybqst48a1RWSpFZNIrOiOIIbO9w3zZmsPB9oucqCthwOtF+kZGgMgLzuD7RtKua2ujJ31Zdy5sZz1pflpjlhErteV7giUCAR359SFwZAYogRxqL1nuvVSTVk+d2wsp2ljOXduLOemdcW6axBZYVQ0JFdkZjRUFdJQVchDt9cAMDYxyVtnetl3qpvmU93sPdHFtw6EIqXCnExury/jzvpy7myoYGd9GSV52en8CiIrxvDYBCcvDPDD8wOc6OznfN8Inf0jdPaPMjQ6wcj4BKPjk4yMTzI+6VEn2DB/6gM38eGmuoU+4qopEci8sjMzuLW2jFtry/jlextxd073DNN8sot9p7rZd6qbz790jEkPfR22ri3mjo3l7Goop2ljBbXl+RpmQwTo7B+h+WQ3e0920Xyyi0One5lI6FhaVpBNZWEOlUW5VBfnkpOZQW52BjmZGWRlGkRD3hhQX1GQkhhVNCTXrH9knAOtF2k+2c2+lm72n+qmL2qltK4kjzsbytm1sZymhgpuXl9Cpvo2yCrn7py8MDh90m8+2c3xzgEAcrMyuK2ujKaN5dy0voQbqgtprCqkIGdprsdVNCQpUZSbxb2bq7h3cxUAE5PO0bN97DvVxd7oCujbb56Z3ndnfRm7Gipo2ljO7fVlS/YDEEmVsYlJjpzujU783TSf6qKzfxQIV/pNGyv4yK46mhoq2F5TsmyHi9EdgaRU+8Wh6SujvSe7OHquD/fQdHX7hhKaGirY1VDOnRsrqC7OTXe4IlfUPzLO/pZu9p7spvlkF/tbLjI0NgGEYpumhnJ2RX/Tm6qKllUPf7UakmWjZ2iM11vCj2jvyW4OtF6cbp3UUFkwnRiaGirYVFWoegZJq46+EZpPdvFadDFz5Ewo388w2LahhKaNFeEut6GctSV56Q73ipQIZNkaHZ/k0Ome6cTQfLKL7sHQp6GiMIc7pyqgGyrYvqGUnCw1W5XUSCzf33uii+ZT3ZxIKN+fKtrcFbWUK15hLeWUCGTFcHeOdw7MSgwnLwwC4cd4e134Md7ZUM4d9eWU5q+sH6MsH+MTk7x1pi+c+KO/t87+EWCmfH9XQzm7GlfHRYgSgaxoHX0j0xXQic3vppqtTt2aNzVUUFOmXtAyv57BMfa3drO/5SKvt3Tz+qluBkZD+X5NWT53NYa/o7saKrihenmV7y8GJQJZVQZHx3mj5WJIDKe6Zv2gN5TmzapnuHFtsZqtxtDEpPODc33TJ/39Ld38sCMU82QY3Li2OKFit4INMbiAUPNRWVUKcrJ49+Yq3h01Wx2fmOTts32hddKpbl49cYHdUS/o4rws7qgPQ2PsqC1lR00pVUVqnbTanO8d5s22nukr/gOtF6cvDioKc9hZV8aH7qhlZ10Zt9aVUZSrU18i3RHIquMeRl1tjoqT9p3s5ui5vuntG0rz2F5Tyq21pWyvCcmhUslhxTjXO8zBth4OtvdwqD3Mz/eFsv3MDOPm9cXcUV/OzvoydtaVs7GyQK3P0B2BxIyZTT/3+Wd21gLQNzzG4dO90yeQg+09/N2Rc9PvqSnLZ0dNKTtqS7lpXTFb1xVTU6ZhMtJpahj1t8/2cuh07/RJvyM66Vv0jI17N1dNJ/QdNXrGxrVQIpBYKM7L5p5NldyzqXJ6Xe/wWDi5JCSHFw6fnXlPbhY3rivmpmjauq6ErWuLKS1QS6XFdqF/hKNn+zh6ro+jZ/t4+2wf75zrmy7eyTDYvKaIH91SxfYNIWFvW19CoYp4FoWKhkQS9AyN8YNz4UR09Gzv9Empb3h8ep/1pXncUF1EY1UYK6axupBNVYXUlOVreO4rGJuYpLVrkBOdA5zoHOCHHWH0zWPnB6abbUIo09+6NtyVTU03rSvWkCTXSUVDIkkqzc+ebkkyxd050zM8fbV69GwfxzsH+Js32mcliOzMUCS1qaqQjZUhMdSU54d5WT5lBdmruqjJ3bkwMEp79xBt3UO0XxykvXuI1u4hTnQO0NI1OGvUzfKCbBqrCnnv1urp4rit64qpLspd1f9Oy5ESgcgCzIwNZflsKMvnn2xdM73e3ekaGOVE5wDHo6vcEx1h/r1jnQyPTc46TkFO5vRx1pfkUVWcQ1VR7vRUHS2X5i+vhOHu9A6N09E/HI2dP0pH38j0dL5vmPaLQ5y+OHTJdy7OzaKmPJ+b1xfzwI51NFYVsam6kMbKQsoLc9L0jWQuJQKRa2RmVBblUlmUS1PCHQTMJInTF4fDlfHFYU5fHKK9e4jTPUO8daaXroHRWVfIU7IzjeK8bEryssI8P4vi3Giel01+dia5WRnkZGWQm5VBbnbm9Bj2WQl9JuaW+k46jIxPMDI+ycjYBMPjk4yMTTI8PsHI2CT9I2P0Do3TOzwWpqnXQ2PMEybZmRYlsFy2ri3mx7aumb4Dqi0voKY8Xz2/VwglApEUSEwSO2pL591nctLpHhyls380ekJVuMK+MDBK79AYfcPj9A2P0Ts8TkdfP33D4/QOjTE0NjHviflaZWcauVmZFOVmUZKfRUleNmuK89hcnUVJfjYledmUFWRTXRxO+tXRyX+53bnItVMiEEmTjIyZZLGV4qt67/hEeJTh1CMNpx5vODYRht6YMus1Ft1BZJCXlUludga5WZnqeS1KBCIrUVZmBlmZGRSqH5wsArV1ExGJOSUCEZGYUyIQEYk5JQIRkZhTIhARiTklAhGRmFMiEBGJuZQmAjO738yOmtkxM3tqnu31ZvaSme03szfN7IFUxiMiIpdKWSIws0zgC8AHgG3AI2a2bc5uvwl8zd13Ag8Df5SqeEREZH6pvCO4Czjm7sfdfRR4Fnhozj4OlESvS4HTKYxHRETmkcpEUAO0Jiy3ResS/TbwC2bWBjwP/Op8BzKzJ8ys2cyaOzo6UhGriEhspbuy+BHgz929FngA+LKZXRKTuz/j7k3u3lRdXb3kQYqIrGapTATtQF3Ccm20LtHjwNcA3P0VIA+oSmFMIiIyRyoTwV5gi5k1mlkOoTJ495x9WoB/CmBmNxMSgcp+RESWUMoSgbuPA08C3wHeIrQOOmxmnzazB6Pd/i3wK2Z2APgq8Kj73OcqiYhIKqX0eQTu/jyhEjhx3acSXh8B7k1lDCIicmXpriwWEZE0UyIQEYk5JQIRkZhTIhARiTklAhGRmFMiEBGJOSUCEZGYUyIQEYk5JQIRkZhTIhARiTklAhGRmFMiEBGJOSUCEZGYUyIQEYk5JQIRkZhTIhARiTklAhGRmFMiEBGJOSUCEZGYUyIQEYk5JQIRkZhTIhARiTklAhGRmFMiEBGJOSUCEZGYUyIQEYk5JQIRkZhTIhARiTklAhGRmMtKdkczywTWJr7H3VtSEZSIiCydpO4IzOxXgXPAi8C3o+m5JN53v5kdNbNjZvbUZfb5OTM7YmaHzewrVxG7iIgsgmTvCD4BbHX3C8keOLqD+ALwPqAN2Gtmu939SMI+W4DfAO51924zW5N86CIishiSrSNoBXqu8th3Acfc/bi7jwLPAg/N2edXgC+4ezeAu5+/ys8QEZHrlOwdwXHgZTP7NjAytdLdP3uF99QQEsiUNuDuOfvcCGBm/whkAr/t7i/MPZCZPQE8AVBfX59kyCIikoxkE0FLNOVE02J+/hbgvUAt8PdmtsPdLybu5O7PAM8ANDU1+SJ+vohI7CWVCNz9aQAzK4qW+5N4WztQl7BcG61L1Aa86u5jwAkz+wEhMexNJi4REbl+ybYa2m5m+4HDwGEz22dmtyzwtr3AFjNrNLMc4GFg95x9/oZwN4CZVRGKio4nH76IiFyvZIuGngF+3d1fAjCz9wL/A3j35d7g7uNm9iTwHUL5/xfd/bCZfRpodvfd0bafMLMjwATwyatpmSQispTGxsZoa2tjeHg43aFcVl5eHrW1tWRnZyf9HnNfuMjdzA64+20LrVsKTU1N3tzcvNQfKyLCiRMnKC4uprKyEjNLdziXcHcuXLhAX18fjY2Ns7aZ2T53b5rvfck2Hz1uZv/RzBqi6TdREY6IxMzw8PCyTQIAZkZlZeVV37EkmwgeA6qBv4qm6midiEisLNckMOVa4ksqEbh7t7v/a3e/I5o+MdUJTEREls4LL7zA1q1b2bx5M5/5zGcW5ZhXrCw2sz9w918zs28Bl1QmuPuDixKFiIgsaGJigo9//OO8+OKL1NbWsmvXLh588EG2bdt2XcddqNXQl6P571/Xp4iIyHV77bXX2Lx5M5s2bQLg4Ycf5pvf/GZqE4G774te3u7uf5i4zcw+Afy/6/p0EZEV6ulvHebI6d5FPea2DSX81k9dvotWe3s7dXUz/XRra2t59dVXr/tzk60s/qV51j163Z8uIiJpt1AdwSPAPwcazSyxV3Ax0JXKwERElrMrXbmnSk1NDa2tM2N5trW1UVNTc93HXaiO4PvAGaAK+K8J6/uAN6/700VEJGm7du3inXfe4cSJE9TU1PDss8/yla9c//O8FqojOAWcAt513Z8kIiLXJSsri89//vO8//3vZ2Jigscee4xbbrn+O5Okxhoys3uAzwE3E4ahzgQG3L3kuiMQEZGkPfDAAzzwwAOLesxkK4s/DzwCvAPkAx8lPIZSRERWuGQTAe5+DMh09wl3/5/A/akLS0RElkqyw1APRs8UeMPMfpdQgZx0EhERkeUr2ZP5LxLqBZ4EBghPHvvZVAUlIiJLJ9lHVZ6KXg4BT6cuHBERWWoLdSg7yDyDzU1x91sXPSIREVlSC90RfHBJohARkaQ89thjPPfcc6xZs4ZDhw4tyjGvWEfg7qeuNC1KBCIikrRHH32UF154YVGPmVRlsZn1mVlvNA2b2YSZLe6weyIisqD77ruPioqKRT1mspXFxVOvLTwH7SHgnkWNRERkJfnbp+DswcU95rod8IHFeerY1bjqvgAe/A3w/sUPR0REllqyYw19KGExA2gChlMSkYjISpCGK/dUSbZn8U8lvB4HThKKh0REZIVLto7gl1MdiIiILOyRRx7h5ZdfprOzk9raWp5++mkef/zx6zpmskVDm4A/JFQQO/AK8G/c/fh1fbqIiFyVr371q4t+zGQri78CfA1YD2wAvg4sfjQiIrLkkk0EBe7+ZXcfj6a/APJSGZiIiCyNZCuL/9bMngKeJRQNfQR43swqANxdD7IXEVmhkk0EPxfNPzZn/cOExLBp0SISEVnG3J3Qr3Z5cr/sOKGXlWyrocarPrKIyCqTl5fHhQsXqKysXJbJwN25cOECeXlXV3KfbKuhbOBfAvdFq14G/sTdxxZ43/2E1kaZwJ+6+7w9MMzsZ4FvALvcvTm50EVEllZtbS1tbW10dHSkO5TLysvLo7a29qrek2zR0B8D2cAfRcu/GK376OXeYGaZhAfcvw9oA/aa2W53PzJnv2LgE8CrVxW5iMgSy87OprFx9RWQJJsIdrn7bQnL3zWzAwu85y7g2FRfAzN7ltAb+cic/f4T8DvAJ5OMRUREFlGyzUcnzOyGqYWog9nEAu+pAVoTltuiddPM7A6gzt2/faUDmdkTZtZsZs3L+ZZMRGQlSvaO4JPAS2Y21ZO4AbiuYSfMLAP4LPDoQvu6+zPAMwBNTU1XXyUuIiKXlewdwT8CfwJMAl3R61cWeE87UJewXButm1IMbAdeNrOThOErdptZU5IxiYjIIkg2EXwJaCSU53+O0G/gywu8Zy+wxcwazSyH0Odg99RGd+9x9yp3b3D3BmAP8KBaDYmILK1ki4a2u/u2hOWXzGxupe8s7j5uZk8C3yE0H/2iux82s08Dze6++0rvFxGRpZFsInjdzO5x9z0AZnY3sOCVu7s/Dzw/Z92nLrPve5OMRUREFlGyieBO4Ptm1hIt1wNHzewg4emVt6YkOhERSblkE8H9KY1CRETSJtmxhk6lOhAREUmPZFsNiYjIKqVEICISc0oEIiIxp0QgIhJzSgQiIjGnRCAiEnNKBCIiMadEICISc0oEIiIxp0QgIhJzSgQiIjGnRCAiEnNKBCIiMadEICISc0oEIiIxp0QgIhJzSgQiIjGnRCAiEnNKBCIiMadEICISc0oEIiIxp0QgIhJzSgQiIjGnRCAiEnNKBCIiMadEICISc0oEIiIxl9JEYGb3m9lRMztmZk/Ns/3XzeyImb1pZv/XzDamMh4REblUyhKBmWUCXwA+AGwDHjGzbXN22w80ufutwDeA301VPCIiMr9U3hHcBRxz9+PuPgo8CzyUuIO7v+Tug9HiHqA2hfGIiMg8UpkIaoDWhOW2aN3lPA787XwbzOwJM2s2s+aOjo5FDFFERJZFZbGZ/QLQBPzefNvd/Rl3b3L3purq6qUNTkRklctK4bHbgbqE5dpo3Sxm9uPAfwDe4+4jKYxHRETmkco7gr3AFjNrNLMc4GFgd+IOZrYT+BPgQXc/n8JYRETkMlKWCNx9HHgS+A7wFvA1dz9sZp82swej3X4PKAK+bmZvmNnuyxxORERSJJVFQ7j788Dzc9Z9KuH1j6fy80VEZGHLorJYRETSR4lARCTmlAhERGJOiUBEJOaUCEREYi6lrYZEZAlNToQpkVnC6wzIyFzamGRFUCIQSbeJMRjogP7zYT7QAcM9MNwb5iM9s5fHh6NpNMwnovnk+MKfZZmQlQfZeWGelQtZ+WGeWwx5pQlT2czrggooWgNFa6GgCjJ16lhN9L8pkkqjA3CxFXraoKc1mtqg93R04j8PQ92Xf392YXQyLgnzwmrIzo9O4jnRPA8yo9ezrvh99rHcowQyEuZjwzNJZWwIRvuh81yUdHpgbJD5GRRUhqRQVA1F66C0FsrqoLQOyjaG5ey86/3XkyWiRCByvQa74MKx2VPXiXDSn3uSt0woqYGSDVB9IzT8SLjSLqyO5mugsAryyyG3JL1X3uOjMBLdhQx0hqTVfw76O6J5tNz5Peg7DT45+/2Fa0JyKKuHys2zp/yytHwlmZ8SgUgyJiehpwXOHYHzR2af9BNP9pYJ5Q1QsQlqm8IVcmlddLVcC8XrV045fVYOZFWFxFR5w5X3nRgPyeBidNdzsSVMPa1w+g04shs8of6ioGomKVRtgTXbYO22kCQT6zVkSSgRiMw1cAHOH45O+tG84+1QdDKlpCacHG/5mdlXumX1kJmdvtjTJTMrfPey+vm3j49C98lL75yOvQhv/MXMfrmlsObmkBTWbIO1t4Tl/PIl+RpxpUQg8dZ3Fk7vD1etp/fDmQPQf3Zme35FOBnd/vPRyekWWHNTqFiV5GXlhKKw6hsv3TbUDeffgnOHw/z8ETj4lzDyxZl9Suthw22w/nbYcDus3wmFlUsV/aqnRCDx0X9+zkn/Deg7E200qN4Km94bTvxrt8Ha7aFCVEUVqZVfDhvfHaYp7tDbPnNXduZA+H9761sz+5TWwfrbZhLDhttDMZZcNSUCWZ0mxuHsm9CyB1pegfZ94cQCgEHVjdB4H2zYGa4y1+2A3KJ0RiyJzEKdSmkt3PgTM+uHLoakcOaNkBjOvAFvPzezvbwBandB7V2hjmbdjngW1V0lJQJZHUb6oG1vdOLfA23NMDYQtpXVh6vNqZP++ltVtLNS5ZfBpveEacrQxZD0T+8PfwMn/gEOfj1sy8oL/++1TVFy2AUl69MR+bJm7r7wXstIU1OTNzc3pzsMSbfeM+FKv2UPtO6BswdD80XLCEU69e+C+nvCVLIh3dHKUpoqVmp9LVwQtL0W7iImRsP2klqo2wV198DGd4W/l5XSkus6mNk+d2+ab5vuCGT5m5yEzqPRif/VML94KmzLLghXe/d9Mpz0a5pC5yuJr8Ripe0fCuvGR+DMm+GOoW1vSBKH/zpsyymGurtCUqh/F9TcGTrtxYgSgSw/Y8PhNr91z0xRz/DFsK1wTTjh3/2xMF93q8qAZWFZudFdwK6ZdRdbo4uLV+DUK/Dd/xzWZ2SH4qSpxFB3dxhiYxVT0ZCk32AXtL46c9I//frMbXzllqiIJyrqqdikVjySGtN/h1FiOL0fJsfCtuqbZxJD/btCB8EV5kpFQ0oEsrTcQ8eiqR9cy57QWQuiK7HbZ078dXerOaCkz9hQaG02lRhaX4PRvrCtpDb8nU4lh+qbIWN5j+qvOgJJn4lxOHdophlny56ZDlu5paFsdseHo7LZO2JXNivLWHZ+GAuq4UfC8uTEzN/yqe/Dye/BoW+EbbmlUH/3zEXMhjtW1KB7SgSyuEb6ob155sTf1jwzNENpHTT+aPix1N0Thg6IQWsNWSUyMkMHtvW3hToq99BoIfEi552/C/tm5oR6hsS722Vcz6CiIbk+Pe2hUrf1tfBDOHswGlzMomacd8/8EFZguarIVUmsZ2jZA+2vJ9Qz3DRzEbT2ljA2VU7BkoWmOgJZHBPjobt/y6szJ/+e1rAtKz80u5u+AtoVxs8XibOxoVDpPJUYWl4NDxqaUloX+rkUVof6sJyi6GFB0TMmMrKixhEW5o33hSRyDVRHINdmuGemzXXLnlBxNlXMU7w+XOW/6+OhnF/NOEUulZ0/exylqT4xHW9D5zthBNa+s9B1PNxJjA6GBwX5xPzH+8nPXnMiuBIlAgkmxsLoj6dfDyf89v1hFEg86q17C9z2SHRre1e4klEzTpGrk5ER6sbW3Hzl/SbGZxKCO+Bhnp2aoiQlgjhyD1cg7ftCGWb7vjBWy/hw2J5fEYp5tj0YrvprmzQ2j8hSysyCzKUbBFGJYLWbGA+3n2cPwrmDoZv96f0zPXWzC8JAbLs+Gppv1twZnjmrq32R2FAiWE2Ge0PxzrlD4Qr/7MHwoI+pK/3MnNBy4ZafDif8DXeE5XQ+F1dE0k5ngJVooBM6jkaVTj+Ymfe2zeyTXxHGYt/10TBftyOMwa8KXRGZQ4lgOXIPj+/rPhGGY5iaOo+Fk/7ghZl9swvCw783vjs8BnDdraH9fskGFe+ISFJSmgjM7H7gD4FM4E/d/TNztucCXwLuBC4AH3H3k6mMaVkYG4a+06HZWO/p8LjE3jPQ0xKd9E/BSO/s9xRUhQ4oN30wPFKxams48ZfULvsxTkRkeUtZIjCzTOALwPuANmCvme129yMJuz0OdLv7ZjN7GPgd4COpimlRTYyHJ2CNzplG+mCoK/QwHLww83qoOyz3nQmv58ouCOOnlzeGDlnlDTNT2UY9RlFEUiaVdwR3Acfc/TiAmT0LPAQkJoKHgN+OXn8D+LyZmaeiu/PrX4bvfy48xQoPc58MxTDT7XSnlifn7OcJyx4ecjExsvBnWmYYX6SgMpTZV2wKRTjF68NUsh6KN0DxutALV0U5IpIGqUwENUBrwnIbcPfl9nH3cTPrASqBzsSdzOwJ4AmA+vr6a4umoCJ04jALHaSI5pYxZ53NLM/aL2GfrJzQFTy7AHIKZ6bsgtDevqAinPh1cheRFWBFVBa7+zPAMxDGGrqmg9z0k2ESEZFZUlnL2A4kDjdZG62bdx8zywJKCZXGIiKyRFKZCPYCW8ys0cxygIeB3XP22Q38UvT6nwHfTUn9gIiIXFbKioaiMv8nge8Qmo9+0d0Pm9mngWZ33w38GfBlMzsGdBGShYiILKGU1hG4+/PA83PWfSrh9TDw4VTGICIiV6aeSCIiMadEICISc0oEIiIxp0QgIhJzK+7h9WbWAZy6xrdXMafXcgzoO8eDvnM8XM933uju1fNtWHGJ4HqYWbO7N6U7jqWk7xwP+s7xkKrvrKIhEZGYUyIQEYm5uCWCZ9IdQBroO8eDvnM8pOQ7x6qOQERELhW3OwIREZlDiUBEJOZikwjM7H4zO2pmx8zsqXTHk2pm9kUzO29mh9Idy1Ixszoze8nMjpjZYTP7RLpjSjUzyzOz18zsQPSdn053TEvBzDLNbL+ZPZfuWJaCmZ00s4Nm9oaZNS/68eNQR2BmmcAPgPcRHpm5F3jE3Y9c8Y0rmJndB/QDX3L37emOZymY2Xpgvbu/bmbFwD7gp1f5/7MBhe7eb2bZwPeAT7j7njSHllJm9utAE1Di7h9MdzypZmYngSZ3T0kHurjcEdwFHHP34+4+CjwLPJTmmFLK3f+e8IyH2HD3M+7+evS6D3iL8FzsVcuD/mgxO5pW9dWdmdUCPwn8abpjWS3ikghqgNaE5TZW+Qki7sysAdgJvJrmUFIuKiZ5AzgPvOjuq/07/wHw74HJNMexlBz4OzPbZ2ZPLPbB45IIJEbMrAj4S+DX3L033fGkmrtPuPvthOeC32Vmq7Yo0Mw+CJx3933pjmWJ/Yi73wF8APh4VPS7aOKSCNqBuoTl2midrDJROflfAv/L3f8q3fEsJXe/CLwE3J/mUFLpXuDBqMz8WeDHzOwv0htS6rl7ezQ/D/w1obh70cQlEewFtphZo5nlEJ6NvDvNMckiiypO/wx4y90/m+54loKZVZtZWfQ6n9Ag4u20BpVC7v4b7l7r7g2E3/F33f0X0hxWSplZYdT4ATMrBH4CWNTWgLFIBO4+DjwJfIdQgfg1dz+c3qhSy8y+CrwCbDWzNjN7PN0xLYF7gV8kXCW+EU0PpDuoFFsPvGRmbxIueF5091g0qYyRtcD3zOwA8BrwbXd/YTE/IBbNR0VE5PJicUcgIiKXp0QgIhJzSgQiIjGnRCAiEnNKBCIiMadEIHIFZlZmZv8qer3BzL6R7phEFpuaj4pcQTRm0XNxGcFV4ikr3QGILHOfAW6IBnV7B7jZ3beb2aPATwOFwBbg94EcQoe2EeABd+8ysxuALwDVwCDwK+6+anv+ysqkoiGRK3sK+GE0qNsn52zbDnwI2AX8F2DQ3XcSenT/i2ifZ4Bfdfc7gX8H/NFSBC1yNXRHIHLtXoqee9BnZj3At6L1B4Fbo1FQ3w18PQyDBEDu0ocpcmVKBCLXbiTh9WTC8iTht5UBXIzuJkSWLRUNiVxZH1B8LW+MnoVwwsw+DGF0VDO7bTGDE1kMSgQiV+DuF4B/NLNDwO9dwyF+Hng8GjnyMKv8EamyMqn5qIhIzOmOQEQk5pQIRERiTolARCTmlAhERGJOiUBEJOaUCEREYk6JQEQk5v4/2ioOJZbfuzAAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plot_population(guess_dynamics)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Optimize"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the following we optimize the guess field $\\epsilon_{0}(t)$ such\n",
+    "that the intended state-to-state transfer $\\ket{\\Psi_{\\init}} \\rightarrow\n",
+    "\\ket{\\Psi_{\\tgt}}$ is solved, via the `krotov` package's central\n",
+    "`optimize_pulses` routine.  It requires, besides the previously defined\n",
+    "`objectives`, information about the optimization functional $J_T$ (implicitly,\n",
+    "via `chi_constructor`, which calculates the states $\\ket{\\chi} =\n",
+    "\\frac{J_T}{\\bra{\\Psi}}$).\n",
+    "\n",
+    "Here, we choose $J_T = J_{T,\\text{ss}} = 1 - F_{\\text{ss}}$ with $F_{\\text{ss}}\n",
+    "= \\Abs{\\Braket{\\Psi_{\\tgt}}{\\Psi(T)}}^2$, with $\\ket{\\Psi(T)}$ the forward\n",
+    "propagated state of $\\ket{\\Psi_{\\init}}$. Even though $J_T$ is not explicitly\n",
+    "required for the optimization, it is nonetheless useful to be able to calculate\n",
+    "and print it as a way to provide some feedback about the optimization progress.\n",
+    "Here, we pass as an `info_hook` the function `krotov.info_hooks.print_table`,\n",
+    "using `krotov.functionals.J_T_ss` (which implements the above functional; the\n",
+    "`krotov` library contains implementations of all the \"standard\" functionals used in\n",
+    "quantum control). This `info_hook` prints a tabular overview after each\n",
+    "iteration, containing the value of $J_T$, the magnitude of the integrated pulse\n",
+    "update, and information on how much $J_T$ (and the full Krotov functional $J$)\n",
+    "changes between iterations. It also stores the value of $J_T$ internally in the\n",
+    "`Result.info_vals` attribute.\n",
+    "\n",
+    "The value of $J_T$ can also be used to check the convergence. In this example,\n",
+    "we limit the number of total iterations to 10, but more generally, we could use\n",
+    "the `check_convergence` parameter to stop the optimization when $J_T$ falls below\n",
+    "some threshold. Here, we only pass a function that checks that the value of\n",
+    "$J_T$ is monotonically decreasing. The\n",
+    "`krotov.convergence.check_monotonic_error` relies on\n",
+    "`krotov.info_hooks.print_table` internally having stored the value of $J_T$ to\n",
+    "the `Result.info_vals` in each iteration."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-06-05T03:32:43.421801Z",
+     "start_time": "2021-06-05T03:30:58.833915Z"
+    },
+    "attributes": {
+     "classes": [],
+     "id": "",
+     "n": "15"
+    },
+    "execution": {
+     "iopub.execute_input": "2021-01-13T19:19:47.283227Z",
+     "iopub.status.busy": "2021-01-13T19:19:47.277756Z",
+     "iopub.status.idle": "2021-01-13T19:20:24.011943Z",
+     "shell.execute_reply": "2021-01-13T19:20:24.012611Z"
+    },
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "iter.      J_T    ∫gₐ(t)dt          J       ΔJ_T         ΔJ  secs\n",
+      "0     9.51e-01    0.00e+00   9.51e-01        n/a        n/a     1\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/goerz/Documents/Programming/github/krotov/src/krotov/parametrization.py:106: UserWarning: Pulse value -2.7755575615628915e-18 < 0 out of range for SquareParametrization. Clip to 0.\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1     8.18e-01    4.34e-02   8.62e-01  -1.33e-01  -8.97e-02     2\n",
+      "2     4.89e-01    1.16e-01   6.04e-01  -3.30e-01  -2.14e-01     1\n",
+      "3     2.55e-01    1.06e-01   3.61e-01  -2.34e-01  -1.28e-01     1\n",
+      "4     1.69e-01    4.31e-02   2.12e-01  -8.58e-02  -4.27e-02     1\n",
+      "5     1.26e-01    2.13e-02   1.48e-01  -4.30e-02  -2.16e-02     2\n",
+      "6     1.01e-01    1.27e-02   1.13e-01  -2.57e-02  -1.29e-02     2\n",
+      "7     8.35e-02    8.47e-03   9.20e-02  -1.71e-02  -8.62e-03     2\n",
+      "8     7.13e-02    6.04e-03   7.74e-02  -1.22e-02  -6.15e-03     1\n",
+      "9     6.22e-02    4.53e-03   6.67e-02  -9.13e-03  -4.61e-03     1\n",
+      "10    5.51e-02    3.51e-03   5.86e-02  -7.09e-03  -3.58e-03     1\n",
+      "11    4.94e-02    2.81e-03   5.22e-02  -5.66e-03  -2.86e-03     1\n",
+      "12    4.48e-02    2.29e-03   4.71e-02  -4.63e-03  -2.33e-03     2\n",
+      "13    4.10e-02    1.91e-03   4.29e-02  -3.85e-03  -1.94e-03     1\n",
+      "14    3.77e-02    1.61e-03   3.93e-02  -3.25e-03  -1.64e-03     2\n",
+      "15    3.49e-02    1.38e-03   3.63e-02  -2.78e-03  -1.40e-03     1\n",
+      "16    3.25e-02    1.19e-03   3.37e-02  -2.41e-03  -1.22e-03     1\n",
+      "17    3.04e-02    1.04e-03   3.15e-02  -2.10e-03  -1.06e-03     1\n",
+      "18    2.86e-02    9.15e-04   2.95e-02  -1.85e-03  -9.35e-04     2\n",
+      "19    2.69e-02    8.12e-04   2.77e-02  -1.64e-03  -8.30e-04     2\n",
+      "20    2.55e-02    7.25e-04   2.62e-02  -1.47e-03  -7.42e-04     2\n",
+      "21    2.41e-02    6.51e-04   2.48e-02  -1.32e-03  -6.67e-04     2\n",
+      "22    2.29e-02    5.88e-04   2.35e-02  -1.19e-03  -6.02e-04     2\n",
+      "23    2.19e-02    5.34e-04   2.24e-02  -1.08e-03  -5.47e-04     3\n",
+      "24    2.09e-02    4.87e-04   2.14e-02  -9.85e-04  -4.99e-04     2\n",
+      "25    2.00e-02    4.45e-04   2.04e-02  -9.02e-04  -4.57e-04     2\n",
+      "26    1.92e-02    4.09e-04   1.96e-02  -8.28e-04  -4.20e-04     2\n",
+      "27    1.84e-02    3.77e-04   1.88e-02  -7.64e-04  -3.87e-04     2\n",
+      "28    1.77e-02    3.48e-04   1.80e-02  -7.06e-04  -3.58e-04     2\n",
+      "29    1.70e-02    3.23e-04   1.73e-02  -6.55e-04  -3.32e-04     2\n",
+      "30    1.64e-02    3.00e-04   1.67e-02  -6.09e-04  -3.09e-04     2\n",
+      "31    1.58e-02    2.80e-04   1.61e-02  -5.68e-04  -2.88e-04     2\n",
+      "32    1.53e-02    2.61e-04   1.56e-02  -5.30e-04  -2.69e-04     2\n",
+      "33    1.48e-02    2.45e-04   1.51e-02  -4.97e-04  -2.52e-04     2\n",
+      "34    1.44e-02    2.30e-04   1.46e-02  -4.66e-04  -2.36e-04     3\n",
+      "35    1.39e-02    2.16e-04   1.41e-02  -4.38e-04  -2.22e-04     2\n",
+      "36    1.35e-02    2.03e-04   1.37e-02  -4.13e-04  -2.09e-04     2\n",
+      "37    1.31e-02    1.92e-04   1.33e-02  -3.89e-04  -1.98e-04     1\n",
+      "38    1.27e-02    1.81e-04   1.29e-02  -3.68e-04  -1.87e-04     1\n",
+      "39    1.24e-02    1.71e-04   1.26e-02  -3.48e-04  -1.77e-04     1\n",
+      "40    1.21e-02    1.62e-04   1.22e-02  -3.30e-04  -1.68e-04     1\n",
+      "41    1.18e-02    1.54e-04   1.19e-02  -3.13e-04  -1.59e-04     1\n",
+      "42    1.15e-02    1.46e-04   1.16e-02  -2.98e-04  -1.51e-04     1\n",
+      "43    1.12e-02    1.39e-04   1.13e-02  -2.83e-04  -1.44e-04     2\n",
+      "44    1.09e-02    1.33e-04   1.10e-02  -2.70e-04  -1.37e-04     1\n",
+      "45    1.07e-02    1.27e-04   1.08e-02  -2.57e-04  -1.31e-04     1\n",
+      "46    1.04e-02    1.21e-04   1.05e-02  -2.46e-04  -1.25e-04     1\n",
+      "47    1.02e-02    1.15e-04   1.03e-02  -2.35e-04  -1.19e-04     1\n",
+      "48    9.95e-03    1.10e-04   1.01e-02  -2.25e-04  -1.14e-04     1\n"
+     ]
+    }
+   ],
+   "source": [
+    "opt_result = krotov.optimize_pulses(\n",
+    "    objectives,\n",
+    "    pulse_options=pulse_options,\n",
+    "    tlist=tlist,\n",
+    "    propagator=krotov.propagators.expm,\n",
+    "    chi_constructor=krotov.functionals.chis_ss,\n",
+    "    info_hook=krotov.info_hooks.print_table(J_T=krotov.functionals.J_T_ss),\n",
+    "    check_convergence=krotov.convergence.Or(\n",
+    "        krotov.convergence.value_below('1e-2', name='J_T'),\n",
+    "        krotov.convergence.check_monotonic_error,\n",
+    "    ),\n",
+    "    store_all_pulses=True,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-06-05T03:32:56.118352Z",
+     "start_time": "2021-06-05T03:32:56.013075Z"
+    },
+    "attributes": {
+     "classes": [],
+     "id": "",
+     "n": "16"
+    },
+    "execution": {
+     "iopub.execute_input": "2021-01-13T19:20:24.017864Z",
+     "iopub.status.busy": "2021-01-13T19:20:24.016620Z",
+     "iopub.status.idle": "2021-01-13T19:20:24.020480Z",
+     "shell.execute_reply": "2021-01-13T19:20:24.021053Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Krotov Optimization Result\n",
+       "--------------------------\n",
+       "- Started at 2021-06-04 23:30:58\n",
+       "- Number of objectives: 1\n",
+       "- Number of iterations: 48\n",
+       "- Reason for termination: Reached convergence: J_T < 1e-2\n",
+       "- Ended at 2021-06-04 23:32:43 (0:01:45)"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "opt_result"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Simulate the dynamics under the optimized field"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Having obtained the optimized control field, we can simulate the dynamics to\n",
+    "verify that the optimized field indeed drives the initial state\n",
+    "$\\ket{\\Psi_{\\init}} = \\ket{0}$ to the desired target state\n",
+    "$\\ket{\\Psi_{\\tgt}} = \\ket{1}$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-06-05T03:32:58.670288Z",
+     "start_time": "2021-06-05T03:32:58.489361Z"
+    },
+    "attributes": {
+     "classes": [],
+     "id": "",
+     "n": "18"
+    },
+    "execution": {
+     "iopub.execute_input": "2021-01-13T19:20:24.180368Z",
+     "iopub.status.busy": "2021-01-13T19:20:24.179669Z",
+     "iopub.status.idle": "2021-01-13T19:20:24.181940Z",
+     "shell.execute_reply": "2021-01-13T19:20:24.182439Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "opt_dynamics = opt_result.optimized_objectives[0].mesolve(\n",
+    "    tlist, e_ops=[proj0, proj1])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-06-05T03:33:00.704052Z",
+     "start_time": "2021-06-05T03:33:00.461526Z"
+    },
+    "attributes": {
+     "classes": [],
+     "id": "",
+     "n": "19"
+    },
+    "execution": {
+     "iopub.execute_input": "2021-01-13T19:20:24.224283Z",
+     "iopub.status.busy": "2021-01-13T19:20:24.222618Z",
+     "iopub.status.idle": "2021-01-13T19:20:24.408840Z",
+     "shell.execute_reply": "2021-01-13T19:20:24.409310Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYIAAAEGCAYAAABo25JHAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAAAf80lEQVR4nO3dfZRcdZ3n8fe3q7qqu6o76TxiSCd0IIhERNAG3WFEnJURsgqe0RlhV3cYUDwz4DDjrHPw7Cwj7Ow5OLqOjuJoRpk54kgOPqxGiDAcDTqjPCQgTwkGMkBIB8hjd9LP1Q/f/ePeTipNVXd1uu+93bmf1zl9qurWvbe+faDzqd/vd+/vZ+6OiIikV13SBYiISLIUBCIiKacgEBFJOQWBiEjKKQhERFIum3QBU7V48WJva2tLugwRkTnl0Ucf3e/uSyq9N+eCoK2tjS1btiRdhojInGJmO6u9p64hEZGUUxCIiKScgkBEJOUUBCIiKacgEBFJuciCwMxuN7O9ZvZ0lffNzP7ezHaY2ZNm9paoahERkeqibBH8M3DJBO9fCpwe/lwL/EOEtYiISBWR3Ufg7r8ws7YJdrkc+JYH82A/ZGYtZrbM3V+Jop7NLx7k357dV/lNs8qba98Vq7j3RPvXXopVO8kUzhF8Zu01TqW+aueuzxinLCpy/qqFFPNz7pYVkdRI8q9zObCr7HVHuO01QWBm1xK0Gli5cuVxfdhjOzv58qYdr9mu5Rii11Ko54sfOoeLzliadCkiUsGc+Jrm7uuAdQDt7e3H9U/3x995Gh9/52nTraPK9ir7T/U8Uzr31GqpptL+Uz13tY8cGBph+6vd/M09z/DH336Mf/3zC1mxsDC1AqsVsvcZePkx6NoFA10wOhz8+Gi4k5U1XyZ7Hr6u9Ly8CVTxHCIxesP7YMV5M37aJINgN7Ci7HVruG3WqtZFM/V/E9Lxj0hTPsvi1Xluv6qdd37uAW7btINbP3D29E763P1w/02wd1u4wSA/DzJZqMuC1YWJFcbTZM+PpJuXJZrXdg6RuC089YQLgg3A9Wa2HngbcCiq8QFJ1rL5jVz+5pO558lXuOXys8hlj/MahQe/Cvd9Ghathvf+Hax6J8xfAdnczBYskjKRBYGZ3QlcBCw2sw7gr4F6AHf/GrARWAvsAPqAP4qqFknexWtO4ruPdrD5xYNcsHrx1E/w9PeDEDjzffCBb0I2P/NFiqRUlFcNXTnJ+w5cF9Xny+xywerFmMEjLxxHEAwcgo2fguXt8MF/gkx9NEWKpNScGCyWua+Yz3Lq4iJbXz489YMf+hr0HYAP/0AhIBIBTTEhsXnjyfPZ9vKhqR00MgRbvgmrL4aTz4mkLpG0UxBIbM5cNo+XDw1weGCo9oOe/zn07IF2DSGJREVBILE5ZVFwD8Gug321H7Tth8HloavfHU1RIqIgkPisXDgWBP21HeAOO34Kp/2OrhISiZCCQGKzYsEUWwT7n4Xul+G0d0VYlYgoCCQ28wv1zGvIsquzxiB46cHgse0d0RUlIgoCidfJLY28cmigtp07NkPjwuC2ehGJjIJAYrWkOc++7sHadu54FJa/VRO8iURMQSCxqjkIhgaCMQLdOyASOQWBxGosCKpNxX3E/u3gI7B0TTyFiaSYgkBitaQpT2lklMP9wxPvuCecZvqkN0ZflEjKKQgkVkuag/sB9nZPMmC8f3uwvsDC6S0mJCKTUxBIrMaCYF/PJOMEnS8Gaw1kNC+iSNQUBBKrBYVgEZmuvknmG+rcCQvaoi9IRBQEEq+ag6BrJyw4JYaKRERBILFqKQTrCXT2larvNNgdrD/QoiAQiYOCQGLVUJ+hob6OromCoHNn8KiuIZFYKAgkdgsKOTon6hrqGgsCtQhE4qAgkNi1FHITjxGMtQha2mKpRyTtFAQSu5bG+km6hl6EXBMUFsZWk0iaKQgkdguK9RMPFne9FAwUa7I5kVgoCCR28xrq6R6YYIqJnldh3rL4ChJJOQWBxK4pn6VncKIg2AvFpfEVJJJyCgKJXVNDlr7SCCOjFWYgdQ+CoElBIBIXBYHErrkhuKmsYqugvxNGhxQEIjFSEEjsmvPBRHLdAxUuIe3dFzw2nRRjRSLppiCQ2DU1BEFQsUXQszd4LC6JsSKRdFMQSOyawhZBT6Urh3r2hDupa0gkLgoCiV1zw1jXUIUgUNeQSOwUBBK7I0FQsWtoT7AyWUNLvEWJpFikQWBml5jZdjPbYWY3Vnh/pZltMrNfm9mTZrY2ynpkdmjKh1cNVewa2hfcQ1Cn7ygicYnsr83MMsBtwKXAGuBKM1szbre/Au5y93OBK4CvRlWPzB5HB4srXTW0F5o0UCwSpyi/dp0P7HD35929BKwHLh+3jwPzwufzgZcjrEdmiWIug1mVMYKePbqrWCRmUQbBcmBX2euOcFu5zwAfNrMOYCPwiUonMrNrzWyLmW3Zt29fFLVKjMyMpny2ShDs00CxSMyS7oi9Evhnd28F1gJ3mNlranL3de7e7u7tS5ao2+BE0FxpviF36Nuv6adFYhZlEOwGVpS9bg23lbsGuAvA3R8EGoDFEdYks0RTQ/a1g8VD/TBSgsYFyRQlklJRBsFm4HQzW2VmOYLB4A3j9nkJ+M8AZnYmQRCo7ycFmhvq6R4/WDzQFTw2tsRdjkiqRRYE7j4MXA/cBzxDcHXQVjO7xcwuC3f7C+BjZvYEcCdwlbtXmJJSTjRN+Qotgv7O4FEtApFYZaM8ubtvJBgELt92U9nzbcAFUdYgs1NTQ5ZdnX3HbuzvCh51M5lIrJIeLJaUaq501ZC6hkQSoSCQRDRXGixW15BIIhQEkoimfD39QyMMj4we3aiuIZFEKAgkERXXJBjoAgzy8yoeIyLRUBBIIpryGQB6SyNHN/Z3BuMDmnBOJFb6i5NEFHJBi6CvvEXQ36VuIZEEKAgkEcVKLYKBLl0xJJIABYEkonKLoFNXDIkkQEEgiTiybrG6hkQSpyCQRBRyQddQn7qGRBKnIJBEFMMWQW8pbBG4By0CdQ2JxE5BIIk40iIYDFsEg93gI+oaEkmAgkASMTZYfGSMQPMMiSRGQSCJyNQZjfUZ+sa6hgYOB4+6q1gkdgoCSUwxnzl6H0GpN3jMNyVXkEhKKQgkMYVc9uh9BKXu4DGnIBCJm4JAElPIVWgRKAhEYqcgkMQU81l6j7QIxoKgmFxBIimlIJDEFPNZtQhEZgEFgSSmmMscHSMYHBsjUItAJG4KAklMIZc9OsVEqResDuobky1KJIUUBJKYYj5z9IayUm/QLWSWbFEiKaQgkMQU89mjN5SVetQtJJIQBYEkppjLMDTilIZHwxaBgkAkCQoCScyRxWlKw2oRiCRIQSCJOWa5ylIv5JoTrkgknRQEkpixFkHvoFoEIklSEEhixparDIJAYwQiSVEQSGKOWa5yUC0CkaRka93RzDLASeXHuPtLURQl6VB8TYtA00uIJKGmFoGZfQLYA9wP3BP+3F3DcZeY2XYz22FmN1bZ5w/MbJuZbTWz70yhdpnjxloEvYNDwRiB1iIQSUStLYIbgDPc/UCtJw5bELcBFwMdwGYz2+Du28r2OR34NHCBu3ea2dLaS5e5bmyMYKC/F3B1DYkkpNYxgl3AoSme+3xgh7s/7+4lYD1w+bh9Pgbc5u6dAO6+d4qfIXNYIQyCoX4tSiOSpFpbBM8DD5jZPcDg2EZ3/8IExywnCJAxHcDbxu3zegAz+yWQAT7j7veOP5GZXQtcC7By5coaS5bZrrE+6Boa7tPMoyJJqjUIXgp/cuHPTH7+6cBFQCvwCzN7k7t3le/k7uuAdQDt7e0+g58vCRpbwH5kUC0CkSTVFATufjOAmTWFr3tqOGw3sKLsdWu4rVwH8LC7DwEvmNmzBMGwuZa6ZO4r5jOMDIT/O6lFIJKIWq8aOsvMfg1sBbaa2aNm9sZJDtsMnG5mq8wsB1wBbBi3zw8JWgOY2WKCrqLnay9f5rpiPosPjgWBWgQiSai1a2gd8El33wRgZhcB/wj8VrUD3H3YzK4H7iPo/7/d3bea2S3AFnffEL73u2a2DRgBPjWVK5Nk7ivksrjWK5Y5YmhoiI6ODgYGBpIupaqGhgZaW1upr6+v+Zhag6A4FgIA7v6AmU36V+vuG4GN47bdVPbcgU+GP5JCxVyGukF1Dcnc0NHRQXNzM21tbdgsXETJ3Tlw4AAdHR2sWrWq5uNqvXz0eTP7X2bWFv78FerCkRlQyGex4b7gRV6zj8rsNjAwwKJFi2ZlCACYGYsWLZpyi6XWILgaWAL8IPxZEm4TmZZiLkNmSF1DMnfM1hAYczz11RQE7t7p7n/q7m8Jf24YuwlMZDqK+SzZ4b5g4fpsQ9LliMx69957L2eccQarV6/m1ltvnZFzTjhGYGZfdPc/M7MfA6+5ft/dL5uRKiS1irkM9SO9wTxDs/yblkjSRkZGuO6667j//vtpbW3lvPPO47LLLmPNmjXTOu9kg8V3hI+fn9aniFRRyGfJjfbr0lGRGjzyyCOsXr2aU089FYArrriCH/3oR9EGgbs/Gj49x92/VP6emd0A/Hxany6pV8xlaPQBRnNFLY4hc8rNP97KtpcPz+g515w8j79+X/VbtHbv3s2KFUfv021tbeXhhx+e9ufW+rf3hxW2XTXtT5fUK+azFBhgNFtIuhSR1JpsjOBK4L8Cq8ys/K7gZuBglIVJOhRzWYo2wEh2Qe2rJInMAhN9c4/K8uXL2bXr6FyeHR0dLF++fNrnnexv71fAK8Bi4P+Wbe8Gnpz2p0vqFfIZigwwlC2QT7oYkVnuvPPO47nnnuOFF15g+fLlrF+/nu98Z/rreU02RrAT2An8p2l/kkgFxVzQNTRUp64hkclks1m+8pWv8J73vIeRkRGuvvpq3vjG6bdMamqNm9nbgS8DZxJMQ50Bet193rQrkFQr5DIUbYDBusakSxGZE9auXcvatWtn9Jy1DhZ/BbgSeA5oBD5KsAylyLQEg8WDDCgIRBJT8xV77r4DyLj7iLv/E3BJdGVJWhRzwRjBgOmuYpGk1HqhRl+4psDjZva3BAPIuuxbpq1YN0idOX2oRSCSlFr/Mf8IwbjA9UAvwcpjH4iqKEmPogVLYPeiFoFIUmpdqnJn+LQfuDm6ciRtGkeD6XJ7XEEgkpTJbih7igqTzY1x97NnvCJJlbrhYArqnlHdRSCSlMlaBO+NpQpJr3B1sm4FgUhNrr76au6++26WLl3K008/PSPnnHCMwN13TvQzIxVIuoXrFR9SEIjU5KqrruLee++d0XPWNFhsZt1mdjj8GTCzETOb2Wn3JJ1KQYuga7j2hbZF0uzCCy9k4cKFM3rOWgeLjywma8E6aJcDb5/RSiSdwhZB55BaBDLH/ORGePWpmT3n694El87MqmNTMeV7ATzwQ+A9M1+OpM5YEKhFIJKYWuca+r2yl3VAOzAQSUWSLqVuAA4MKQhkjkngm3tUar2z+H1lz4eBFwm6h0Smp9TLCBk6B3WjukhSah0j+KOoC5GUKvVSyjTSWxpJuhKROeHKK6/kgQceYP/+/bS2tnLzzTdzzTXXTOuctXYNnQp8iWCA2IEHgT939+en9ekipR6GM4309Y/g7gTXIohINXfeeeeMn7PW9vh3gLuAZcDJwHeBma9G0mewh+FMgeFRpzQymnQ1IqlUaxAU3P0Odx8Of74NmiVMZkCpl+H6IgB9g+oeEklCrUHwEzO70czazOwUM/tLYKOZLTSzmb2zQdKl1ItngyDoGRxOuBiRdKr1qqE/CB8/Pm77FQRjBqfOWEWSLqUePBd8l+jTgLHMAbN9LMu96jyhVdV61dCqKZ9ZpBalXmhaAUBvSS0Cmd0aGho4cOAAixYtmpVh4O4cOHCAhoap9dzXetVQPfDHwIXhpgeAr7v70CTHXUJwtVEG+Ia7V7wDw8w+AHwPOM/dt9RWupwQSj1YvgnQGIHMfq2trXR0dLBv376kS6mqoaGB1tbWKR1Ta9fQPwD1wFfD1x8Jt3202gFmliFY4P5ioAPYbGYb3H3buP2agRuAh6dUuZwYSr3U5YOprNQikNmuvr6eVatOvA6SWoPgPHd/c9nrn5nZE5Mccz6wY+xeAzNbT3A38rZx+/1v4LPAp2qsRU4Uo6NQ6iXTGLQIejVYLJKIWq8aGjGz08ZehDeYTdaOXw7sKnvdEW47wszeAqxw93smOpGZXWtmW8xsy2xukskUDfcDTn3DWItAXUMiSai1RfApYJOZjd1J3AZMa9oJM6sDvgBcNdm+7r4OWAfQ3t4+9SFxmZ3C1cnqG4Mg6FOLQCQRtbYIfgl8HRgFDobPH5zkmN3AirLXreG2Mc3AWcADZvYiwfQVG8ysvcaaZK4LF6WpL8wD1CIQSUqtQfAtYBVBf/6XCe4buGOSYzYDp5vZKjPLEdxzsGHsTXc/5O6L3b3N3duAh4DLdNVQioRrEdTlmyjkMhojEElIrV1DZ7n7mrLXm8xs/KDvMdx92MyuB+4juHz0dnffama3AFvcfcNEx0sKhEFArkgxP0qfrhoSSUStQfCYmb3d3R8CMLO3AZN+c3f3jcDGcdtuqrLvRTXWIieKI0HQRDHXS6/uIxBJRK1B8FbgV2b2Uvh6JbDdzJ4iWL3y7EiqkxNbuDoZuSKF3KBaBCIJqTUILom0Ckmn8hZB/pBaBCIJqXWuoZ1RFyIpVBYEhVyWzr5SsvWIpJQWipXkhJePkivSlM/qqiGRhCgIJDmlXrAMZPMUchlNQy2SEAWBJGewB3JNYEZRLQKRxCgIJDmlXginoC7kMvSWRo5rUQ0RmR4FgSSn1AO5YJnKYj7LyKgzOKwF7EXipiCQ5JR6jwZBLgNouUqRJCgIJDmlcIwAKOSDK5k1TiASPwWBJKcsCIq5IAjUIhCJn4JAklPWNVTIB11DPWoRiMROQSDJKQuCpvxYi0BBIBI3BYEkp9R7dIwgHCzWfEMi8VMQSDJGR4+5fLQ5Xw9A98BQklWJpJKCQJIx1Bc8hjeUzW8MguBQv4JAJG4KAklG2epkAM0NWcwUBCJJUBBIMo7MPBq0COrqjHkN9QoCkQQoCCQZZVNQj5nfqCAQSYKCQJJRtijNmPmN9XT1KQhE4qYgkGRUCIKWgloEIklQEEgyKnQNzWus57CCQCR2CgJJxrirhgBaNEYgkggFgSRj8NirhiAcI+gf0uI0IjFTEEgyBruDx3zzkU3zG+sZGXV6NQOpSKwUBJKMwcOQbYBs7simloLuLhZJgoJAkjHYfUxrAI5OM9HVV0qiIpHUUhBIMgYPvyYI5mm+IZFEKAgkGYPdkJ93zKaWxqCbSJeQisRLQSDJqNQ1VBjrGlIQiMQp0iAws0vMbLuZ7TCzGyu8/0kz22ZmT5rZT83slCjrkVmkQotAU1GLJCOyIDCzDHAbcCmwBrjSzNaM2+3XQLu7nw18D/jbqOqRWWbgMDQcGwTFXIZsnSkIRGIWZYvgfGCHuz/v7iVgPXB5+Q7uvsndwxVKeAhojbAemU0qDBabGS2FHAd7ddWQSJyiDILlwK6y1x3htmquAX5S6Q0zu9bMtpjZln379s1giZII94pjBACLm3Ls7xlMoCiR9JoVg8Vm9mGgHfhcpffdfZ27t7t7+5IlS+ItTmbeUD/4SMUgWNKcZ1+PWgQicYoyCHYDK8pet4bbjmFm7wb+J3CZu+urYBoMHg4exw0WAyxpyrO/W/8biMQpyiDYDJxuZqvMLAdcAWwo38HMzgW+ThACeyOsRWaTI/MMVQiC5jz7egY18ZxIjCILAncfBq4H7gOeAe5y961mdouZXRbu9jmgCfiumT1uZhuqnE5OJEdaBJXGCPKUhkc5PDAcc1Ei6ZWN8uTuvhHYOG7bTWXP3x3l58ssVWHm0TGLm4O7i/f3DB65r0BEojUrBoslZQbCFkFDpTGCBgCNE4jESEEg8auhRbBPl5CKxEZBIPGbaLC4KQ+oRSASJwWBxG+CFsGCQo5MnalFIBIjBYHEb/AQZBsh89rB4Lo6Y2Exx/5u3VQmEhcFgcSvyvQSY5Y05TXNhEiMFAQSv4HXTjhXbklznj3dAzEWJJJuCgKJX/9BKCys+nbrgkY6OvtjLEgk3RQEEr/+TmisHgQrFhbo6hvi8IDWJRCJg4JA4tfXCY0Lqr69cmEBgF0H+6ruIyIzR0Eg8Zuka2jFgrEgUPeQSBwUBBKv4RKUeibpGmoEoKNTLQKROCgIJF79B4PHQvWuofmN9TTns7ykriGRWCgIJF79ncHjBGMEZsaKhQWNEYjEREEg8eoLWwQTdA1B0D20S5eQisRCQSDx6g0XomtaOuFuKxYELYLRUa1UJhI1BYHEq2csCE6acLfTljYxODyqG8tEYqAgkHj17IG67KRdQ2e8LpiC4jevHo6jKpFUUxBIvHr2QHEp1E38v97rTwqCYPur3XFUJZJqCgKJV/eeSccHAJryWU5ZVGDry2oRiERNQSDx6tkz6fjAmDe3tvD4rq5o6xERBYHE7PDLMG9ZTbueu7KFVw8P8OohTUktEiUFgcRnsAf69kPLKTXt3n5KMKD88AsHoqxKJPUUBBKfrp3B44K2mnZfc/I8Wgr1/Ntz+6OrSUQUBBKjzrEgqK1FkKkzLli9mAe272NEN5aJREZBIPHpfCF4bGmr+ZC1Zy1jf8+guodEIqQgkPjs2QaFxROuRTDeu96whOZ8lrs274qwMJF0UxBIfF59ApadDWY1H1LIZflgeyv3PPWKZiMViYiCQOIxPAh7fwOvO3vKh378wtPI1Bm33L0Nd40ViMw0BYHE46WHYHQIVpw/5UNfN7+BT178eu7ftofP3rtdYSAyw7JJFyAp8ey9kMnDqRcd1+Ef/e1T2Xmgj6/9/D945pXD/MlFp/HWUxaQzei7jMh0RRoEZnYJ8CUgA3zD3W8d934e+BbwVuAA8CF3fzHKmiQBA4fg8X+B178HcsXjOkVdnfE37z+LVYuL/P1Pn+ND6x4il6ljWUsDCwo56jNGps6oM8MdnKDVEDwPVdg+1rrwcNvYc9yPHDf+fCJJue5dq1n7ptruzJ+KyILAzDLAbcDFQAew2cw2uPu2st2uATrdfbWZXQF8FvhQVDVJAg6/Aj/+Uxjshnf8xbROZWZ89B2ncsX5K/nFs/t4oqOL3Z39HB4YZnhklOFRZ3hkFDMwDMIxaSMcnzYw6o6MVY/tVz52beELO/L+0e1Hn0/r1xA5bo25TCTnjbJFcD6ww92fBzCz9cDlQHkQXA58Jnz+PeArZmYeRSfwY3fAr75c4Y0qH1WxhKnsO0P7T/ncVXZP4vcc6oeBLrAMrP08nHxOteKmpCmfZe2blkXyzUgkjaIMguVA+cXfHcDbqu3j7sNmdghYBBwzp4CZXQtcC7By5crjq6awCJaeWfm9ql/xKmyfyr4ztn+U566yf9VvvVM4d109LFwFr78UFq+udkIRSdicGCx293XAOoD29vbjay28YW3wIyIix4jykovdwIqy163htor7mFkWmE8waCwiIjGJMgg2A6eb2SozywFXABvG7bMB+MPw+QeBn0UyPiAiIlVF1jUU9vlfD9xHcPno7e6+1cxuAba4+wbgm8AdZrYDOEgQFiIiEqNIxwjcfSOwcdy2m8qeDwC/H2UNIiIyMd2WKSKScgoCEZGUUxCIiKScgkBEJOVsrl2taWb7gJ3Hefhixt21nAL6ndNBv3M6TOd3PsXdl1R6Y84FwXSY2RZ3b0+6jjjpd04H/c7pENXvrK4hEZGUUxCIiKRc2oJgXdIFJEC/czrod06HSH7nVI0RiIjIa6WtRSAiIuMoCEREUi41QWBml5jZdjPbYWY3Jl1P1MzsdjPba2ZPJ11LXMxshZltMrNtZrbVzG5IuqaomVmDmT1iZk+Ev/PNSdcUBzPLmNmvzezupGuJg5m9aGZPmdnjZrZlxs+fhjECM8sAzwIXEyyZuRm40t23TXjgHGZmFwI9wLfc/ayk64mDmS0Dlrn7Y2bWDDwKvP8E/+9sQNHde8ysHvh34AZ3fyjh0iJlZp8E2oF57v7epOuJmpm9CLS7eyQ30KWlRXA+sMPdn3f3ErAeuDzhmiLl7r8gWOMhNdz9FXd/LHzeDTxDsC72CcsDPeHL+vDnhP52Z2atwH8BvpF0LSeKtATBcmBX2esOTvB/INLOzNqAc4GHEy4lcmE3yePAXuB+dz/Rf+cvAn8JjCZcR5wc+Fcze9TMrp3pk6clCCRFzKwJ+D7wZ+5+OOl6oubuI+5+DsG64Oeb2QnbFWhm7wX2uvujSdcSs99297cAlwLXhV2/MyYtQbAbWFH2ujXcJieYsJ/8+8C/uPsPkq4nTu7eBWwCLkm4lChdAFwW9pmvB37HzL6dbEnRc/fd4eNe4P8RdHfPmLQEwWbgdDNbZWY5grWRNyRck8ywcOD0m8Az7v6FpOuJg5ktMbOW8HkjwQURv0m0qAi5+6fdvdXd2wj+jn/m7h9OuKxImVkxvPgBMysCvwvM6NWAqQgCdx8GrgfuIxhAvMvdtyZbVbTM7E7gQeAMM+sws2uSrikGFwAfIfiW+Hj4szbpoiK2DNhkZk8SfOG5391TcUllipwE/LuZPQE8Atzj7vfO5Aek4vJRERGpLhUtAhERqU5BICKScgoCEZGUUxCIiKScgkBEJOUUBCITMLMWM/uT8PnJZva9pGsSmWm6fFRkAuGcRXenZQZXSads0gWIzHK3AqeFk7o9B5zp7meZ2VXA+4EicDrweSBHcEPbILDW3Q+a2WnAbcASoA/4mLufsHf+ytykriGRid0I/Ec4qdunxr13FvB7wHnA/wH63P1cgju6/3u4zzrgE+7+VuB/AF+No2iRqVCLQOT4bQrXPeg2s0PAj8PtTwFnh7Og/hbw3WAaJADy8ZcpMjEFgcjxGyx7Plr2epTgb6sO6ApbEyKzlrqGRCbWDTQfz4HhWggvmNnvQzA7qpm9eSaLE5kJCgKRCbj7AeCXZvY08LnjOMV/A64JZ47cygm+RKrMTbp8VEQk5dQiEBFJOQWBiEjKKQhERFJOQSAiknIKAhGRlFMQiIiknIJARCTl/j/uSupPfBGQbAAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plot_population(opt_dynamics)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To gain some intuition on how the controls and the dynamics change throughout the optimization procedure, we can generate a plot of the control fields and the dynamics after each iteration of the optimization algorithm. This is possible because we set `store_all_pulses=True` in the call to `optimize_pulses`, which allows to recover the optimized controls from each iteration from `Result.all_pulses`. The flag is not set to True by default, as for long-running optimizations with thousands or tens of thousands iterations, the storage of all control fields may require significant memory."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-06-05T03:33:02.484143Z",
+     "start_time": "2021-06-05T03:33:02.446161Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2021-01-13T19:20:24.421916Z",
+     "iopub.status.busy": "2021-01-13T19:20:24.420852Z",
+     "iopub.status.idle": "2021-01-13T19:20:24.423448Z",
+     "shell.execute_reply": "2021-01-13T19:20:24.423968Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def plot_iterations(opt_result):\n",
+    "    \"\"\"Plot the control fields in population dynamics over all iterations.\n",
+    "\n",
+    "    This depends on ``store_all_pulses=True`` in the call to\n",
+    "    `optimize_pulses`.\n",
+    "    \"\"\"\n",
+    "    fig, [ax_ctr, ax_dyn] = plt.subplots(nrows=2, figsize=(8, 10))\n",
+    "    n_iters = len(opt_result.iters)\n",
+    "    for (iteration, pulses) in zip(opt_result.iters, opt_result.all_pulses):\n",
+    "        controls = [\n",
+    "            krotov.conversions.pulse_onto_tlist(pulse)\n",
+    "            for pulse in pulses\n",
+    "        ]\n",
+    "        objectives = opt_result.objectives_with_controls(controls)\n",
+    "        dynamics = objectives[0].mesolve(\n",
+    "            opt_result.tlist, e_ops=[proj0, proj1]\n",
+    "        )\n",
+    "        if iteration == 0:\n",
+    "            ls = '--'  # dashed\n",
+    "            alpha = 1  # full opacity\n",
+    "            ctr_label = 'guess'\n",
+    "            pop_labels = ['0 (guess)', '1 (guess)']\n",
+    "        elif iteration == opt_result.iters[-1]:\n",
+    "            ls = '-'  # solid\n",
+    "            alpha = 1  # full opacity\n",
+    "            ctr_label = 'optimized'\n",
+    "            pop_labels = ['0 (optimized)', '1 (optimized)']\n",
+    "        else:\n",
+    "            ls = '-'  # solid\n",
+    "            alpha = 0.5 * float(iteration) / float(n_iters)  # max 50%\n",
+    "            ctr_label = None\n",
+    "            pop_labels = [None, None]\n",
+    "        ax_ctr.plot(\n",
+    "            dynamics.times,\n",
+    "            controls[0],\n",
+    "            label=ctr_label,\n",
+    "            color='black',\n",
+    "            ls=ls,\n",
+    "            alpha=alpha,\n",
+    "        )\n",
+    "        ax_dyn.plot(\n",
+    "            dynamics.times,\n",
+    "            dynamics.expect[0],\n",
+    "            label=pop_labels[0],\n",
+    "            color='#1f77b4',  # default blue\n",
+    "            ls=ls,\n",
+    "            alpha=alpha,\n",
+    "        )\n",
+    "        ax_dyn.plot(\n",
+    "            dynamics.times,\n",
+    "            dynamics.expect[1],\n",
+    "            label=pop_labels[1],\n",
+    "            color='#ff7f0e',  # default orange\n",
+    "            ls=ls,\n",
+    "            alpha=alpha,\n",
+    "        )\n",
+    "    ax_dyn.legend()\n",
+    "    ax_dyn.set_xlabel('time')\n",
+    "    ax_dyn.set_ylabel('population')\n",
+    "    ax_ctr.legend()\n",
+    "    ax_ctr.set_xlabel('time')\n",
+    "    ax_ctr.set_ylabel('control amplitude')\n",
+    "    plt.show(fig)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-06-05T03:33:09.156115Z",
+     "start_time": "2021-06-05T03:33:03.660132Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2021-01-13T19:20:24.551224Z",
+     "iopub.status.busy": "2021-01-13T19:20:24.550324Z",
+     "iopub.status.idle": "2021-01-13T19:20:27.395973Z",
+     "shell.execute_reply": "2021-01-13T19:20:27.396514Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAfEAAAJNCAYAAAAh0kzuAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAADxKUlEQVR4nOy9d5wcd33//3zPzPZrku7UZUvCtpAtCxfZBmyMDQRMNzW0JKaHngIJJIRA+EIIIQmBH4GYmkAgJLQAMS3ExJjibmNblmzZslWsruu7t2Xm8/tj5jM7u1d0kvZu73Tv5+Oxuun72dHdvub9/ryLGGNQFEVRFGX+4bR7AIqiKIqinBgq4oqiKIoyT1ERVxRFUZR5ioq4oiiKosxTVMQVRVEUZZ6iIq4oiqIo8xSv3QM4Xnp7e83atWvbPQxFURRFmRVuu+22w8aYvon2zTsRX7t2Lbfeemu7h6EoiqIos4KIPDLZPnWnK4qiKMo8RUVcURRFUeYpKuKKoiiKMk+Zd3PiiqIoytygWq2yZ88exsbG2j2UU4JsNsvq1atJpVLTPkdFXFEURTkh9uzZQ2dnJ2vXrkVE2j2ceY0xhiNHjrBnzx7WrVs37fPUna4oiqKcEGNjYyxZskQFvAWICEuWLDlur4aKuKIoinLCqIC3jhO5lyriiqIoijJPURFXlCZ83+emm27CGNPuoSiKokyJiriiJDDGcPnll/P4xz+eb3zjG+0ejqIo0+CDH/wgGzZs4LLLLuPlL385H/vYx7jiiivi6p6HDx/Gluv2fZ93vetdXHTRRWzevJl//ud/BmDfvn1cfvnlnHfeeWzatImf//zn+L7PNddcw6ZNmzj33HP5h3/4h3Z9xEnR6HRFSbB7925++ctfAvDDH/6Ql7zkJW0ekaIoU3HLLbfwzW9+k7vuuotqtcoFF1zAhRdeOOnxn//85+nu7uaWW26hXC5z6aWX8vSnP51vfetbPOMZz+DP//zP8X2fYrHInXfeyd69e7nnnnsAGBgYmKVPNX1UxBUlwdatWwHo6Ojgxz/+McYYDdxRlGlyxRVXjNv20pe+lDe/+c0Ui0We9axnjdt/zTXXcM0113D48GFe/OIXN+z72c9+dsz3/MUvfsHzn/98stks2WyW5z73uVMe/+Mf/5jf/OY3sadtcHCQBx54gIsuuojXvOY1VKtVrr76as477zzWr1/PQw89xNve9jae/exn8/SnP/2Y45lt1J2uKAnsE/fFF1/Mnj172L17d5tHpCjKieB5HkEQADSkbRlj+OQnP8mdd97JnXfeyc6dO3n605/O5Zdfzg033MCqVau45ppr+Nd//VcWLVrEXXfdxRVXXMFnPvMZXve617Xr40yKWuKKkuCOO+6go6ODvr6w69+OHTs47bTT2jwqRZkfTGU55/P5Kff39vZOy/Ju5tJLL+WNb3wj73nPe6jVanz/+9/nDW94A2vXruW2227j4osvbohvecYznsGnP/1pnvKUp5BKpbj//vtZtWoVhw8fZvXq1bz+9a+nXC5z++2386xnPYt0Os2LXvQiNmzYwKte9arjHt9M03YRF5ENwNcTm9YD7zPGfLw9I1IWMvfeey/d3d3xk/s999zDU57ylDaPSlGUybjooot43vOex+bNm1m2bBnnnnsu3d3dvPOd7+SlL30p1157Lc9+9rPj41/3utfx8MMPc8EFF2CMoa+vj+985zv87Gc/42//9m9JpVJ0dHTwr//6r+zdu5dXv/rVsUX/13/91+36mJMicymNRkRcYC9wiTFmwv6pW7ZsMdpPXJkpli9fjud5vPjFL+aTn/wkr3/96/nMZz7T7mEpypzkvvvuY+PGje0eBiMjI3R0dFAsFrn88su59tprueCCC9o9rBNionsqIrcZY7ZMdHzbLfEmngo8OJmAK8pMYozh6NGjrF69mtHRUbLZLNu3b2/3sBRFOQZveMMb2Lp1K2NjY/ze7/3evBXwE2GuifjLgK+1exDKwmRkZIRqtYqIkEqlSKVS7Ny5s93DUhTlGHz1q19t9xDaxpyJTheRNPA84D8n2PcGEblVRG49dOjQ7A9OWRDY360gCOjt7cXzPPbv39/mUSmKokzOnBFx4JnA7caYA807jDHXGmO2GGO22KhhRWk1Bw8eBIjF2/M8yuUyo6OjbR6ZoijKxMwlEX856kpX2si+ffsAcByHxYsX4zjhn8ejjz7azmEpiqJMypwQcREpAL8FfKvdY1EWLnv37o2Xe3p6SKfTADz00EPtGpKiKMqUzAkRN8aMGmOWGGMG2z0WZeFiLW7Xddm3bx+u6wIq4opyKvHxj3+cYrEYrz/rWc86rpro3/3ud/nIRz5y0uNINmg5GeaEiCvKXGDfvn2ISOxOT6VSADzwwANtHpmiKK2iWcSvu+46enp6pn3+8573PN797nfPwMhODBVxRYnYv38/rutijMHzvPgPW9PMFGVu8/d///ds2rSJTZs28fGPf5yHH36Yxz72sbzyla9k48aNvPjFL6ZYLPKJT3yCRx99lCuvvJIrr7wSgLVr13L48OH4nGuuuYazzjqLV77ylfzP//wPl156KWeeeSY333wzAF/60pd461vfCsB5550Xv3K5HP/3f//H6Ogor3nNa7j44os5//zz+a//+i8ASqUSL3vZy9i4cSMveMELKJVKLfnsKuKKEjEwMICIYIxhZGSEcrmM4zjs2bOn3UNTFGUSbrvtNr74xS9y00038etf/5rPfvaz9Pf3s337dt785jdz33330dXVxT/90z/x9re/nZUrV3L99ddz/fXXj7vWjh07+OM//mO2bdvGtm3b+OpXv8qNN97Ixz72MT784Q+PO942UfngBz/Ili1beOITn8iHPvQhnvKUp3DzzTdz/fXX8653vYvR0VE+/elPk8/nue+++/jABz7Abbfd1pLPP9eKvShK2xgcDEMyXNelUCiwaNEiRIQDB8ZlPSqK0sQf/MEfcOedd7b0mueddx4f//jHpzzmxhtv5AUveAGFQgGAF77whfz85z9nzZo1XHrppQC86lWv4hOf+ATvfOc7p7zWunXrOPfccwE455xzeOpTn4qIcO655/Lwww9PeM4DDzzAu971Lq6//npSqRQ//vGP+e53v8vHPvYxIOygtmvXLm644Qbe/va3A7B582Y2b9483dswJSriihIxPDwMhMVeHMeJvxSGhobaOSxFUU4AEZlyfSIymUy87DhOvO44DrVabdzxIyMjvPSlL+Wzn/0sK1asAMLyzd/85jfZsGHDyQx/2qiIK0rE6Oho7E4vFouUy2WAls1dKcqpzLEs5pniSU96Etdccw3vfve7Mcbw7W9/my9/+cu84x3v4Fe/+hVPeMIT+OpXv8pll10GQGdnJ8PDw/T29p70e7/mNa/h1a9+NU960pPibc94xjP45Cc/ySc/+UlEhDvuuIPzzz+fyy+/nK9+9as85SlP4Z577uE3v/nNSb8/6Jy4osTY9qOpVIpsNsvy5csRESqVCnOp25+iKHUuuOACrrnmGi6++GIuueQSXve617Fo0SI2bNjApz71KTZu3Eh/fz9vetObgLBZylVXXRUHtp0ojzzyCN/4xjf4whe+EAe33XrrrfzFX/wF1WqVzZs3c8455/AXf/EXALzpTW9iZGSEjRs38r73vY8LL7zwpD87zLFWpNNBW5EqM4Xnebiuy5lnnsmLX/xiHnjgAf7zP/+TarVKf3//caWhKMpCYK60Im3m4Ycf5jnPeQ733HNPu4dy3BxvK1K1xBUFqFQq+L4PhHNatVqNdDodz6Mlq7kpiqLMFVTEFYV6UBuEQSxdXV2xOx2YNDJVUZS5x9q1a+elFX4iqIgrCuMj0AcGBjhy5EjcBEVLryqKMhdREVcUiGsniwhBEOC6LkuWLNH66YpyDOZbXNVc5kTupYq4ogBHjhyJlz3Po6OjgxUrVuB5YRbmI4880q6hKcqcJZvNcuTIERXyFmCM4ciRI2Sz2eM6T/PEFQU4evRovCwi7N+/n1wuF4u4BrYpynhWr17Nnj17OHToULuHckqQzWZZvXr1cZ2jIq4o1EVcRPB9n1wuR09PT/xUfPjw4XYOT1HmJKlUinXr1rV7GAsadacrCnDw4MF42XVd8vk8K1eujMsu2rrqiqIocwm1xBUF6O/vj5dd1+XQoUOk02nS6TRAQ/9hRVGUuYJa4opCPTodoFqtks1m6ezsJJVKxdsURVHmGiriikLdXe44DiJCoVBg1apVcSczW81NURRlLqEirig0FnvxPI+BgQH27NkTz4kbY6hUKu0anqIoyoSoiCsKYRtSizEGEaGvrw8R0frpiqLMWVTEFQUYGRkBiMusdnR00NXVRV9fX3zMjh072jI2RVGUyWi7iItIj4h8Q0S2ich9IvKEdo9JWXgUi0VEBGMMjuMwPDzMgQMHqFarsSV+3333tXmUiqIojcyFFLN/BH5ojHmxiKSBfLsHpCw8xsbGAGL3ua2fXigUcByHIAjYvn17m0epKIrSSFtFXES6gcuBawCMMRVAo4eUWadcLgP1BiidnZ2sX78+nhcH2LlzZzuHqCiKMo52u9PXAYeAL4rIHSLyOREptHlMygLERp5bS7xYLLJz505GR0fjefJ9+/a1c4iKoijjaLeIe8AFwKeNMecDo8C7mw8SkTeIyK0icqsW2ldmAlvMJQgCPM+jVqvhOA6LFi2Kq7YlO50piqLMBdot4nuAPcaYm6L1bxCKegPGmGuNMVuMMVuS0cKK0ipqtRoQllwNgoB8Ps8555zDokWL4qptNoJdURRlrtBWETfG7Ad2i8iGaNNTga1tHJKyQPF9v6EnchAE3HXXXQwNDcUFX0qlUruGpyiKMiFzITr9bcC/RZHpDwGvbvN4lAVGEAQNAu66LpVKhXQ6zaJFi2IRt9a6oijKXKHtIm6MuRPY0u5xKAsX26HMBrU5joPrupx99tmUy+W4p7jWT1cUZa7R7jlxRWk7yTajtuBLOp3mjjvu4NChQ3ETlKS1riiKMhdQEVcWPM0BayISW+CdnZ2xOx1C17uiKMpcoe3udEVpN7YNKYQC7nnhn8W6desYGRmJ3ekAhw8fZunSpbM+RkVRlIlQS1xZ8FgRt3XTfd8nk8mwc+dOHnzwQbq7u+Nj77777nYNU1EUZRwq4sqCZ2BgACAuryoiVKtVfN+Pa6dbbr/99nYMUVEUZUJUxJUFjxVxCAXcFnxZvnw5mzZtIpfLxQKvlriiKHMJFXFlwTM0NNSwblPMisUiDz74IIsWLYpFXHuKK4oyl1ARVxY8VsSTc+Ku63L06FFEJF4HOHDgQDuHqiiK0oCKuLLgSUanA7Fwd3V1sXHjRrq6uuKI9eZjFUVR2omKuLLgGR4eBuoV2zzPwxhDLpdjdHSU7u5ucrkc0FgYRlEUpd1onriy4Em6062Qp1Ip9u/fT6VSoVqt0tHRwdGjR+O+44qiKHMBtcSVBY+1xCG0xoMgIAgC0uk0p59+Oh0dHbElrhXbFEWZS6iIKwue0dFRoLEBiojQ09PD6tWr6evri0Vc66crijKXUBFXFjzJLmZAPCc+PDzMr371K0ZHR+no6GjnEBVFUSZERVxZ8DS3IrXBbaVSCREhk8k01E9XFEWZK6iIKwuesbExIHSVu66LMQZjDPl8niuvvJIVK1bQ1dUVH18ul9s1VEVRlAZUxJUFjxVxaJzzzmQy3HHHHZTLZfL5fLz9pptumtXxKYqiTIaKuLLgsWljNqAtlUohIgwODjI0NESlUqFQKMTH/+QnP2nXUBVFURpQEVcWPMncb9uxzHEcHMdh48aNrFy5MhZ2gFtuuaUt41QURWlGRVxZ8NRqNaBeO9261PP5PK7rksvl6O7ujgX+4YcfbtdQFUVRGtCKbcqCx4p40go3xlCr1di6dSuVSoVsNovnefi+z6FDh9o5XEVRlBi1xJUFj+/78bJNL3Mch7GxMXp6eujt7cVxnDi4TeunK4oyV5gTlriIPAwMAz5QM8Zsae+IlIWELaVqq7XZZc/zWL16dVy9raenh/7+fqrVajuHqyiKEjMnRDziSmPM4XYPQll4WBG3DVAs2WyWvXv3UqlUyOfz9Pb2snPnzgbLXVEUpZ3MJRFXlLZgA9lstTYI58UrlUrc4axWq9Hd3d22MSqKokxEy+bEJeRVIvK+aP00Ebl4mqcb4McicpuIvKFVY1KU6WBF3KaVpVIpAKrVKkuWLGHz5s10dnY25IoriqLMBVoZ2PZPwBOAl0frw8CnpnnuZcaYC4BnAm8RkcuTO0XkDSJyq4jcqpHBSiuxkemWZCezVCrFokWLEBGWLFnSUHpVURRlLtBKEb/EGPMWYAzAGNMPpKdzojFmb/TzIPBt4OKm/dcaY7YYY7b09fW1cMjKQqdUKsXLdk7cWubpdJpdu3Zxzz33UCwWGzqZ6by4oihzgVaKeFVEXELXOCLSBwTHOklECiLSaZeBpwP3tHBcijIpyXQxW3bVLlcqFXzfp6+vD9d1G9zp99yjv6KKorSfVor4Jwit6KUi8iHgRuDD0zhvGXCjiNwF3Az8tzHmhy0cl6JMyvDwcLxsXenpdBoRIQgCFi1axMaNG+nr6yOTycTHfuc732nDaBVFURppWXS6MebfROQ24KmAAFcbY+6bxnkPAY9r1TgU5XiYSMStNW5Lrm7bto10Ok13d3fsbr/++uv5y7/8y3YNW1EUBWiBiIvI4sTqQeBryX3GmKMn+x6KMlMMDg42rNuSqyJCJpNh3759iAiVSoVcLofjOPi+z44dO9o0YkVRlDqtsMRvI5wHF+A0oD9a7gF2Aeta8B6KMiPYPHCL67pxI5RKpYKIsHnzZh544AEcxyGbzTI6Okp/f3+bRqwoilLnpOfEjTHrjDHrgf8BnmuM6TXGLAGeA/z4ZK+vKDNJUsRtyVU7J26MobOzk66uLlavXk1nZyc9PT0AjI2NtWO4iqIoDbQysO3xxpjr7Iox5gfAE1t4fUVpOUmL2uaHu64bz4tnMhluu+029u3bR2dnJytXrgTqpVoVRVHaSStF/FERea+IrI1efw482sLrK0rLGRgYaFhPzolns1kOHz4cz4n7vh+LuKIoylyglSL+cqCPMM3s28BS6tXbFGVOMlFgWxAEuK5LpVLBcRzWrVvH6aefTiaTYfny5W0aqaIoynhamWJ2FHhHq66nKLNBUsTtnLjneQRBEFvj3d3d+L5PT08PixYtatdQFUVRxtEyEReR64mqtSUxxjylVe+hKK1msmIvNko9l8tx5513Uq1WSaVSDVXbhoaGtJ66oihtpZWtSN+ZWM4CLwJqkxyrKHOCZhF3XTdeTqfT9Pf3k06n6ejo4MCBAw2i/T//8z+88IUvnPUxK4qiWFrpTr+tadMvROTmVl1fUWaCkZGReNm2Iq3VarFr3RjD6tWr6evro1Qq4Xn1P5kf/vCHKuKKorSVVrrTk5XbHOBCoLtV11eUmWB0dLRh3aaZQdipLJVKsWTJEiqVCsuWLSOfz8fH3nrrrbM6VkVRlGZa6U5PVm6rATuB17bw+orScpKtSJsboIgIHR0d3H///ZRKJVzXpaurC9d18X2f3bt3t3HkiqIorRXxjcaYhjJWIpKZ7GBFmQskRdwWerHz4hBa6iLCypUr2bdvH47jkMlkKBaL43LMFUVRZptW5on/coJtv2rh9RWl5ZTL5XjZ9hO3eeKZTIZKpcKSJUtYuXIlS5cuJZVK0dnZCUCtpnGbiqK0l1Z0MVsOrAJyInI+oTsdoAvIT3qioswBKpVKvGyMacgRt2llvb29lMtlent76erqore3lwMHDrRx1IqiKCGtcKc/A7gGWA38fWL7MPBnLbi+oswY1Wo1XraR557nNbQjHRoa4uDBgziOQ0dHB8uWLePee+9t15AVRVFiTlrEjTH/AvyLiLzIGPPNFoxJUWaNpEs8Gdhma6g7jsPBgwdZvHgxpVKJQ4cOsX79ev73f/8XCLuZZbPZdg1fUZQFTivc6a8yxnwFWCsif9S83xjz9xOcpihzAt/342WbJ27F2/M8isUihUKBNWvWUKlUGBkZaaiffuONN/K0pz2tHUNXFEVpSWCbrUPZAXRO8FKUOUtSxF3XjUXcdd14fry3tzeOSu/t7WXNmjXxOT/60Y/aMWxFURSgNe70f45+fuDkh6Mos4vtC277h1uXOoSu9mw2SzabZevWrdRqNQqFAqtWrYrPv+mmm2Z/0IqiKBGtcKd/Yqr9xpi3n+x7KMpMYUzYs8fWTbdz4hC619PpNPv27QOgq6uLwcFBMpl6+YMHH3xw9getKIoS0Yro9Oaa6Yoyb7AibnFdl1QqFfcV932fWq3G+vXr6ejoYMeOHbGlDmjBF0VR2kqrotNjRKQr3GyGJzllHCLiArcCe40xzznZMSnKdEla4jawLQiC2AofGxujp6cnLvCyYsUKDh8+HB9XLBbbOXxFURY4LavYJiJbRORu4DfAPSJyl4hcOM3T3wHc16qxKMp0SFrh1p1uxdkuiwiLFi3iyJEjPPjggwwPD7No0aKGbmaKoijtopVlV78AvNkYs9YYczrwFuCLxzpJRFYDzwY+18KxKMoxSRZ6sQFtIkIqlcL3fXzfJ51O4/s++/btwxjDkSNHKJfLDbnhyfrriqIos0krRdw3xvzcrhhjbiTsZnYsPg78CRC0cCyKckyaxdfmhts5cSvo/f39FAoFzjjjDJYtW4YxhkKhEJ938803z/bQFUVRgNaK+P+JyD+LyBUi8mQR+SfgZyJygYhcMNEJIvIc4KAxZsrgOBF5g4jcKiK3Hjp0qIVDVhYyw8P1sA07J25/uq6LMSa2yJctWwZAb28vhUKB7u7u+FxbvU1RFGW2aeXE3uOin3/ZtP18wj7jT5ngnEuB54nIs4As0CUiXzHGvCp5kDHmWuBagC1btpjxl1GU42doaChetsKdnBP3PI9KpUJ3dze5XI6hoSGMMSxZsoRly5axbds2AH7961+36yMoirLAaZmIG2OuPIFz3gO8B0BErgDe2SzgijJTJNPDbNpYsvmJzRvv6upi9+7djIyMAJDJZFi9enV87o4dO2Z13IqiKJaWibiI9AC/C6xNXleLvShzlf7+/njZirbneXG5VRvYVqvV4prpnuexZ88eVq5cGZ97+PDhdgxfURSlpe7064BfA3dzAkFqxpifAT9r4XgUZUqOHj3asJ50qdu5cc/zGB4eplAosHjxYiCcF09a4porrihKu2iliGeNMeO6mCnKXCVpiSeD2ZLNT2xt9SVLlsTH9vb2ctZZZ8XrtVqNSqUSl2tVFEWZLVoZnf5lEXm9iKwQkcX21cLrK0pLOXLkSLycLPZihdx1XarVKqlUinw+z/79+3nwwQfZv38/69ata7jWHXfcMdvDVxRFaamIV4C/BX5FWE/9NsJSqooyJ2kObEsGswGxNd7V1cW+ffsYHBwkm80yMjLSUD8d4Prrr5/NoSuKogCtdaf/MXCGMUajfJR5wUTudPsyxmCMiV3kIyMjLF26lEWLFjE6OsqePXsQkbh06y233NKWz6AoysKmlZb4DkAjfJR5w+DgYLzcHMxmxdl1XUqlEul0mp6eHoC42IvruvH5999//6yOXVEUBVpriY8Cd4rI9UDZbtQUM2Wukiz2IiKxeCetccdxKJfLLFu2DBGhVqsRBAG9vb2kUilqtbCy8P79+9v1MRRFWcC0UsS/E70UZV4wOjoaL9ugNiveqVQKCCPPPc+js7OTQ4cOxdZ7Lpcjn8/H9deTDwSKoiizRSsrtv3LsY9SlLlDUsSTDU+AeD7c9326uroYGhpicHCQ7u5uUqkUR44coaOjI45wr1Qq7Nq1i9NOO60tn0VRlIVJK/uJnyki3xCRrSLykH216vqK0mqai7R4nhdb40EQxNHq2WyWo0eP0tHRQV9fHz09PSxdujSeI7fccMMNszh6RVGU1ga2fRH4NGH70SuBfwW+0sLrK0pLKZfj0A08z4vTyzzPiyPPXdelVqthjKG3tzc+vrOzk+XLlzdc75e//OWsjV1RFAVaK+I5Y8xPATHGPGKMeT/w7BZeX1FaSqVSiZdtnrgNZkulUhhj8DyPYrFIR0cHnufh+z6jo6OUy2XWr1/fcL177rlntj+CoigLnFYGtpVFxAEeEJG3AnuBjhZeX1FaSrVajZdtYFsmkwFoSDOzBV9KpRIHDhyIS7E2W+KPPPLILI1cURQlpJWW+DuAPPB24ELgVcDvtfD6itJSbHoYNDY/sbiui+/7cS31AwcO4HkeK1euZPHixaxYsaLheoODgw3XVBRFmWlaGZ1uS1aNAK9u1XUVZabwfT9eTnYvs670VCqF7/v09PTE1d1sO9JsNsumTZsarlcsFtm6dSubN2+e1c+hKMrCpZWWuKLMK5IibgU8CII4VxzqAW+jo6P09PTgefXn3mQnM3s9DW5TFGU2URFXFix2btumknmeF9dKt0IuIlSrVUSErq4uIHTDl0qleD15vZtuuml2P4SiKAuaVga2Kcq8wlrbtma6daVbUbcFX0qlEh0dHTiOw8DAQEPNdTtvbtm+ffusfw5FURYuJy3iIvJJwEy2X2unK/MBz/PiV1LEgyDAGENnZyeDg4MMDg7S0dFBoVBgZGQknje37NmzJw6GUxRFmWlaYYlrz3BlXtJsiSebngBxg5NUKoXrugwMDFAoFFiyZAkA2WyWfD7P2NhYfM2hoSEefPDBcfPliqIoM8FJi3hzzXQR6Yi2j5zstRVlNnAcp6HcqhVzz/MIgoB8Ps/AwACO47B48eKGc3t6ejh69Gi8XqlUuOmmm1TEFUWZFVpZO32TiNwB3AtsFZHbROScVl1fUWaKZGCbbYBii73YbcVikc7OzoY8coC+vr6G69RqNQ1uUxRl1mhlYNu1wB8ZY64HEJErgM8CT5zqJBHJAjcAmWg83zDG/GULx6Uo40gWZbHudNsAxa5bd7vv+4gInZ2dAAwPDzM8PIzv+w311CF00W/dunX2PoiiKAuaVqaYFayAAxhjfgYUpnFeGXiKMeZxwHnAVSLy+BaOS1HG0dyG1Ap4cm4cIJ1OUywWyeVyuK5Lf38/AwMDpFIpOjs7Wb16dcN1Hcdhz5494zqkKYqizAStFPGHROQvRGRt9HovcMxWpCbEzp+notek0e6K0gqGhobi5aSIQxjQZqu2QZj/XSgUGB0dZWRkhM7OzrglabJqmz1+cHCQu+++exY/jaIoC5VWivhrgD7gW8A3gd5o2zEREVdE7gQOAj8xxuikojKjJIPR7Jy4tcItNn3MNkYZGBggk8k09BE/44wzGq4DYXDbLbfcgqIoykzTkjlxEXGBbxljrjyR840xPnCeiPQA3xaRTcaYuK+jiLwBeAPAaaed1oIRKwudw4cPx8tJAW8uuWqMIZvNMjIyQhAELFq0qOE669ati5dteprv+9x2222z80EURVnQtMQSj0Q4EJHuk7zOAHA9cFXT9muNMVuMMVuS0cCKcqIcPHgwXraV2pLz4raOuojEIp7L5eLodWMMpVIpDnZLIiI88MADDa1OFUVRZoJWRqePAHeLyE+AOGroWBXbRKQPqBpjBkQkB/wW8DctHJeijCNpiSej0m3DE1upDYgrt1nBLpfL9Pf3NxxjsfPqR44c4f777+ecczTLUlGUmaOVIv6t6JVkOgFqK4B/iVzyDvAfxpjvt3BcijKOQ4cOxcuO48SWONQ7l1kLfWxsDM/zyGQylMtljh49iud5LF68GNd1SaVSsdXt+z6ZTIaRkRFuvfVWFXFFUWaUVop4jzHmH5MbROQdxzrJGPMb4PwWjkNRjknSnW7nw1OpVEOEehAEsYh3d3cTBAH9/f24rsuSJUviY/P5fNwUxc6LV6tVbr/9dn7v935v9j+coigLhlZGp0/0bXVNC6+vKC3jyJEj8bIVcZtqZozBGBMLOYRCPTQ0FAe3JSu3dXfXQ0FshDrA/fff31BXXVEUpdWctIiLyMtF5HvAOhH5buJ1PXD0WOcrSjvo7++Pl21euA1qS76sNQ5QLBYpFArxumXp0qXxchAEBEGA53kcPnyY+++/f3Y+kKIoC5JWuNN/CewjzAv/u8T2YeA3Lbi+orScZE/wZKlVOz8eBAGO41Cr1ejq6mJ0dLSh9CqE899jY2MsX7684do2QG50dJRbbrmFzZs3z9rnUhRlYdGKLmaPAI8ATzj54SjK7DAyUm+yZ/uIp9NpRAQRiV3qIkImk6G/v59cLhe70YvFIsPDwwANpVdttLp9ALjzzjtn70MpirLgaGUXsxeKyAMiMigiQyIyLCJDxz5TUWafZO10K+K22Iu1pG1bUt/3McZQKBTic4eHh8lkMvT29vK4xz0uvpZNR4NQyB955JGGSHhFUZRW0srAto8CzzPGdBtjuowxncaYrhZeX1FaRqlUipcnakFq1zOZDKOjo6TTaVKpFOVymZGREbLZLD09Pbiuy5lnntlwbWvFWwv+N7/RWSVFUWaGVor4AWPMfS28nqLMGJVKJV62lridF7cudTtHXqvVyOfzGGMYGhrC8zy6uurPp82lV40x+L6P53mUy2XuuOOOWf1siqIsHFqZJ36riHwd+A5he1EAjDHNBWAUpe0kS6La1LJ0Og3UrfFkulg2m2V0dJQgCOjp6WnYt2rVqnjZirh9ua7Lfffdx+joaOyOVxRFaRWttMS7gCLwdOC50es5Lby+orSMWq0WL9v58HQ6HVvkVoCr1SqZTAYIg9my2ey4FDN7PhCfC8Ru+UOHDrFt27ZZ+mSKoiwkWmaJG2Ne3aprKcpMY4PPgFi8oV74xYp4rVajUChQLBYbgtsgTDEbHh6mWq02WOrJeurpdJpSqcRtt93GhRdeOHsfUFGUBUEro9NXi8i3ReRg9PqmiKw+9pmKMvskI8hTqVQcmZ7MGbdinMlkKBaLZDKZWOwrlQr9/f34vk+hUGjoMR4EAb7vA8TR7tu3b28IplMURWkFrXSnfxH4LrAyen0v2qYocw4r0Fa80+l07BKHsIqbMYZ0Ok21Wm2wwmu1GkNDQ7iuy6JFi8jn8yRb5No0s3K5jDGGfD7PgQMHtHqboigtp5Ui3meM+aIxpha9vgRo829lTmM7lVkxh7r1bNPESqVSnIZmI9RFhO7u7rj4y0QFX4DY1V4qlbTwi6IoLaeVIn5ERF4lIm70ehVw5JhnKUobSRZ6se1Ik/PlNrgtl8sBYaU33/fp6upqaIKSTDMD4uh2O0fueR7bt29vqBSnKIpysrRSxF8DvBTYT1hL/cWABrspcxrHcchkMqRSKUQkLr1qRdhGsWezWWq1GmNjY+RyuXER6smCL9adHgRBLOS5XI7Dhw+zffv2Wf18iqKc2rQyOv0R4Hmtup6izAbWje55XhzMZvPEM5kM5XKZTCaD4zgMDw8jIhPme69fvz5eDoKAWq2G7/tx6dZcLhe71C+44IKGPHNFUZQTpZXR6f8iIj2J9UUi8oVWXV9RZgLrRk/2Ek9GqgdBQDabpVKpUKlUKBQKDQLs+z5DQ0MNgW0QWuPVahXf9/F9P26k8vDDD3Pw4MHZ/piKopyitNKdvtkYM2BXjDH9wPktvL6itIRyOS4oiOd5ceqYLbNqjGmY77a53o7jxHPjEAatDQ0NEQQBZ511Vrw9OaderVapVCo4jkN3dzf9/f3cd59WJ1YUpTW0UsQdEVlkV0RkMa0t66ooLeHw4cPxsi30YlPM7Ny4rZmeTqcJgoBKpTJOwIeHh3Ech66uLnp6ehrmyZNCXqvVKBaL5HI5PM/j3nvvZWxsbHY+rKIopzStFPG/A34lIh8UkQ8CvyTsbKYoc4q9e/fGy3Y+PNlLHMLUM9/34/QwEYlF3Pd9RkZGcF23IUq9s7MTqKeY2Tlx65Yvl8t0dnZy6NAhduzYMZsfWVGUU5SWibgx5l+BFwIHotcLjTFfbtX1FaVVPPzww/FyKpWKa6Mnu5lZIU6lUoyNjZHNZmOBt2linZ2dDfPjvb29AA2pZTZK3ZZyzWazVKtV7rvvvriqm6IoyonSUne3MWYrsLWV11SUVvPggw/Gy7aIS3I+vLlaG4QpZhD2Ifd9n87OzoZ5c4A1a9Zw//33x+JtLfFarRYHzNk0tkcffZS9e/dy2mmnzd4HVxTllKOV7vTjRkTWiMj1IrJVRO4VkXe0czzKwuCRRx6Jl221Nmtp29roVmzHxsZiC933fUqlEul0elyeOMBjHvMYoO5OtwKefGWzWTo6OhgaGooFX1EU5URpq4gDNeCPjTFnA48H3iIiZ7d5TMopzp49e+LlTCZDOp2Ou5clC73YLmbWCi8Wi5PmiQdBEIs4EKeW1Wo1qtUqY2NjccpZPp8nm83yyCOPaLqZoignRVtF3Bizzxhze7Q8DNwHrGrnmJRTn0OHDsXLVsRd143nxm2Kmc3vttXabPnV5kItlUqF4eHhBhG3x1hL2wp5uVzG8zx6enoYGhrigQceUGtcUZQTpt2WeIyIrCXMK7+pzUNRTnGOHKmX9LeucWuF2yYo6XSacrkcR60Xi8W4RGuSUqlEsVjEdV3OO+88gNiat0FtQHxde3w6nSaXy7Fr166GlDdFUZTjYU6IuIh0AN8E/sAYMzTB/jeIyK0icmvSilKUEyHZhCSbzZLJZGKRtZXbbIR5JpOhWq1Sq9XGWeGlUikuy9rR0REHqVkBN8bEbnXf9+OSrtbNXigUKBaL7NixoyGvXFEUZbq0XcRFJEUo4P9mjPnWRMcYY641xmwxxmxpLm+pKMdLsViMl7PZbEPpVRtFbpuX2OC2ZivcusYzmUycP55KpRpS0axw2582uC2ZxpZOpzlw4IDOjSuKckK0OzpdgM8D9xlj/r6dY1EWDpVKJV7OZDJxgxMrrq7r4vs+6XQa3/fjnuAWO79tXeJJenp6gHrFNptqVq1WY+u8VquRSqViV36xWOThhx+OO6YpiqJMl3Zb4pcCvwM8RUTujF7PavOYlFOcpFjaNqTJLmZA7EofGxuLm5fY7XYOvFnAAVasWNFwDWuJ23SzSqUSu9MzmQzZbBbP8zh06BD79u2bhU+vKMqpRFtrmxtjbgS0J6Myq1gr2bq/bXoZ0JAn7nkeo6OjDS7yUqkEMK6bmWXdunXccccd8bx4tVqNX7Y9qRVx22c8nU5TqVTYvXs3S5YsIZ/Pz8ZtUBTlFKDdlriizDrWUk6n06TT6TiwzXGcuFpbKpWKq7VZK7xSqcSu9eZqbZZzzjmn4X2sJW6FvFwuUywWGR0dpVwux6ltHR0dHD16lD179mjKmaIo00ZFXFmw2DltW+wl2QDFutJt+pkxhlKpFLcunQjf99mwYQNQTzOzQW22gIx12fu+T7lcZnh4GGNMHCC3f/9+jh49Omv3QFGU+Y2KuLJgyWazcStSG9RmSaaYQRiNboyZcB4ciC3sjRs3AnUrvLmOuu/7cTQ8EHc3q1QqdHZ2Uq1W2bNnT0PwnaIoymSoiCsLllwuF7vGbXR60pVuU8ys1ZzMJ7cYYygWi1QqFdLpNGeffXbDPhvQloxQT7YodRyHbDYbB8wVCgVGRkbYu3evutUVRTkmKuLKgiWfz8fudBvIZsW8Uqk0WOG2/GoSK+C+75PL5eJocxuYZnPNrZAnA91qtRrlchkRiQvJWFe74zj09/fT398/6/dEUZT5hYq4smDJ5/NkMhk8z4st7OZ5cVszPZPJNLjbrYAbY8jn83FUO8DSpUvja9nSqzY/3M6H12o1RIRKpRLPn9vqcZ7nUSqVOHDgQBwNryiKMhEq4sqCIumitu70pIjbzmV2W3OeuL1GqVSK58ibXexr166dsKe4daknt0EY9W6PdxyHXC5HoVBgcHCQgwcP4vv+LNwZRVHmIyriyoJi165d8XJXV1cs1taStt3LkjXTk3niELrXfd+PS7Y289jHPhagIbDNWuJWwKvVaoN1bn/aKHbr6j906BCHDh3S+XFFUSZERVxZUPzyl7+MlwuFQlyxTUTin1DvYtZcM71cLsfV1pIu9CTN3cySTVBs/fQgCOKHASvgVuytYHd2dpJOpzl06BADAwMzc0MURZnXtLVim6LMNr/+9a/jZSvitl664zgEQRBHpNuAM4stm2rrnk/GueeeC9Sj061b3Z4/NjbG2NgY2Wy2IRfdzsfbBwrXdenu7mZ0dJTDhw/jeR6dnZ0zd3MURZl3qCWuLCjuuOOOeLmjoyOu2Gajwm3hFRs5bsXaGBN3M2uOUm/GFnwBYhFPutLtezWXerVWe6VSifuOQ/iwEQQBR44c0UA3RVEaUBFXFhQPP/xwvFwoFOIWpLbcqs3dbo5It+I5WbEXizGGjo6OuJhLsuhLsq+4/Wnfy3oCkoVnkg1TrHfg6NGjlMvlmbk5iqLMO1TElQVFMvc6n8/HVrW1hu1ceDIi3QqpbVk6GbVajVKphO/7LFu2LN7eXLHN1mBPpprZQDc7H57sTW6PcxyHcrlMf3+/VnRTFAVQEVcWGGNjY/FyZ2cnnufFLnM7F22rr9nAtEqlgud5sXXdjHW1VyqVuEXpWWedNa70arLoiy32AsQ/rXVul33fx3EcCoUCuVwujlwvlUoMDg7GDVoURVm4qIgrCwqbc10oFOLob9vgxOaIA+Nqpk/V9MQeY+fXRYTzzz9/nIBba9ta4fb6ruvGueLJNqVA7G4XEXK5XPwgMTIyokKuKIqKuLKwsJbu6tWrG6q1ua4b9/W2Xc1sOthkbnTbWtSWZE2mnF100UXx+1kRT1riQRDELvFKpRKLdXKMtjlKEARx9LrneXFA3sjICAMDA+paV5QFjIq4siBZsWIF+Xw+DmyzkenW6k5Go0+UTmbntV3XHVcMBmDLli3xcrM7vVqtUqlUGkTaWul23b6scNvjrZjbGu3FYpH+/v6GaQJFURYOKuLKgmTFihVxK1IIA9uq1Wqcn23d2xOlk9mCL1P1Fl+7dm2cQpaMTLfBbcmuZtbiT+63Ag7EAm6rydm58VQqRWdnJ8YYBgcHGR0d1cpuirLAUBFXFiS9vb2x29ymdFkr3EaQW0FPUi6X8X3/mAVfXNelr69vXHpZsh2pfZ+keFuBTlrtED5k2Pl6qKeuua4bTwuMjIwwOjoaz6crinLqoxXblAXJokWLKBQKcY54EARxjvbo6Oi4pidQF/B0Oj1pydUkZ5xxBgcOHIgLvDQLtxVta4nbBwfrGreCbq10G4Tn+z4i0tC61H4O25glm81OGk2vKMqpg1riyoJkyZIlDWJsrXDrum6e5z5eAQe44IILxqWZWfEul8uUy2WKxSKlUolKpUK5XKZSqcSibS33sbGxOKK9WCxSLpcbzkk2TsnlcnFpV7tPUZRTFxVxZcGwd+/eeLmnp4d0Oh1bqzZC3eaEJ4X6RAQc4PGPf3y8nBRl+7IFXKz73Fratpa7HYcNYoOwCIx189tCMcViEd/3KZVKDbXf7QOAutcV5dSl7SIuIl8QkYMick+7x6Kc2nzgAx+IlxctWhSnl1nXuS26knSjW9d3KpU6LgEHuPjii4HG6HS7DDTMkQNxhHoyCM7O1dtUNjt/n0ql4g5sthBMOp2OBT3pth8bG2uYT1cU5dSh7SIOfAm4qt2DUE59rrvuung5n8/HYm3nlGu1WhzsBsTW8lTV2ibCVmNbuXJlnK7WHOBm58Ft8RcbDW8D2ZKWu7W4racgmX5mx2fnxG2zlGw2SxAElEolqtVq7H5XFOXUou0iboy5ATja7nEopz4HDx4EwkjvfD4fW+LpdHpcTriNDE+WZT0WVryt6KbTadavXx9b33auO5lOZo+3/cWTxyXFH4iFPtmn3HVdyuUyqVSKcrkcu/x936enp4dUKhVfa2RkhOHh4bhanKIo85+2i7iizBbWyu3t7SWfz8fz4FYobU64dUVbgT8WE4m3nd++6KKLYje6Fd5kbrhdtlayDWBrttrtfjsX3izwNrq+WCzG7vWxsbG4tKwNeqvVagwODsbz54qizG/mhYiLyBtE5FYRufXQoUPtHo4yz3niE59IoVCIg8esG9113dg6dhxn0kIuFhtl3izeyRKtV155ZbxsLfJkYFvS6rbR5M3lWYE4AM5a41a8a7Va3LTFztmXSqVYsMvlMrlcLg6e6+rqij0PIyMjcdCeoijzk3kh4saYa40xW4wxW/r6+to9HGWe89SnPjUWaeueTqfTsYBPlCOexB5nG5NMJN6WJz3pSfE5SWG28902rSxpidvjki51K8h2vNZKt21Mk1a4fTjIZrNxedikdZ7P5ykUCohI3H1NxVxR5ifzQsQVpZWce+65cR540o1uo9MnqoUONAShAXHVtql6jK9fvz5+IEh2KWsW6+SceDI63b6fnf+2jVKS+d+2ZSmEXdEymUzDHP/Y2Bi+78dCXiqV4rgA+/Bi38t6FjS/XFHmB20XcRH5GvArYIOI7BGR17Z7TMqpxyOPPBIvW5cyEAe3JdPLJhLwZMqWrZneXJJ1IkSEM844o6FqW3JO3M53W2G2y8ngN1s3PdmDHOrWveu6sXgny7SOjo7GJVmLxSLGGPL5PMYYisVi3EjFxgWISBzxrmKuKPODtou4MeblxpgVxpiUMWa1Mebz7R6Tcurx6U9/Ol7u7OyMy5Zms9m4c9hELUeTwmrd7MebL37FFVc0uMebK7LZtqRJ8U663pNR7LbUqr0WEKeb2TaqxWIxfhgZHh6Og/hsgxRbOMYKu22jah8abHyAirmizH3aLuKKMht85zvfiZetaCXLrE4k4Ml5aOs6n8hKPxbPfvazARrqpCdd6kkht25tu55siuK6bkNOefKhwIquzXkfHR2Nc8btsogwMjIyTshtYF8yLsDGDCTFvNmNryhK+1ERVxYEO3bsAIirnaVSqVgIreVpSVq+Ns1sOq7zyXjyk5/c0K+82Z3e3F/czr0nXe+28prtKd7cc9w2TykWi2Sz2bgMa6FQiMuvdnR0NAi5FXZbEMaWeBWRWLRtZTjbeEXFXFHmFiriyoLARl7ncrnY6rbpWckmKMnANVtb/USs7yT5fJ5169Y1RKZbV7p1o9ugMjtfnZwvt8dCmGpmm6TY/uLJMq6u61IsFsnn83HEeTabjaPQOzo6ABpc63ZOvVKpxFMMqVSKWq0Wd0VTMVeUuYmKuHLKs23btnh55cqVsSWbLKc6UeDaVFHnx8uVV17ZEKiWFPJkNPrY2FgcXJYsy2oF3fYLt2KfzFVPrheLRRzHYWBgIHbHDw0NUSqVyGazVKtVBgcHqVar8WctlUqxaNt7AMRd1JI12+0cuoq5orQXFXHllOcrX/lKvHzJJZfEjUTS6fS4wLXj7VQ2XV7wghcAjBNwK87JfPFSqRSv25rnyRrq1rWeLPpiHz4qlQq5XK6hZOzIyEicTlYsFgmCgI6ODowxDA8PU61W4ymDUqnE0NBQPC/veV6cX249BEAs8kkxt1MCiqLMHiriyilPsvHJc57znHie2wZsBUEwrZzvk+FJT3oSjuOMK/ZiXeq2B3gysC1ZXtW69K3Fbl3bxpg4mM0+nNRqNXK5HGNjYxQKBTzPY2RkhM7OTjKZDKVSCcdx4trqtsBNoVCII/ftQ4INcLPXHR0djefQk4JuP5v9LCrmijI7qIgrpzSPPvooDzzwQLz+tKc9LRYuG7g23Zzv6WKD15KFXbLZLJs3b27oYNbc0axWqzE2NgbUW6A2W+3GmLibmfUeJGutJ6u5eZ7H8PAwhUIBYwxDQ0N0dHTgum7cCMUGu42OjsYxAvYY+4DjeR65XC5+CLAPGsnPa6PnrWejWCxSKpU0PU1RZhgVceWU5r/+678YGRmJ17u7uxsqrrUicC0Zcd5cqAXCYDTXdXnZy14Wz2cn88GtNW63JQU8ud2Kp537tkKbLM9q3eg2SM1Go3d0dMTNTzo7OxuE3K6Pjo7G6WW2y9vY2Fg8T26Lw9ha7EmXu31lMhlyuVzcPa1UKlEsFuOHJvs5VNgVpTWoiCunLIODg/zkJz9p2Ha8FdeamcjKtuIEdcG2QXO2IpzjOPzO7/xOPIZm0U8u2/nlsbGxcWJvXdxBEMRV16x4WyG36WY2iM3mind1dVGr1RgaGqKzszO21KvVKoVCIT7HXtdG8ieD5iDspGZz7a33wHoB7OfPZDJ0dHSQy+Uaqs3ZQL7me6eirignhoq4ckoSBAE/+9nP2L59e7wtk8kcd8W1ZtFutrInE+yJrPuVK1eyfv36Bmu8eV7cCri1sK2YW4vc5nzXarVYRKvVaiyUSSG3c+G2Kcro6CidnZ1Uq9XYtZ5KpRgZGYnnz23TlOHh4bh6W7IwjC37aoMAbV55ck4/iXXF27Q1IB6nvUeTeTFU2BXl2KiIK6ckDz30EDfeeCNHjx6Nt61cufKYrvOkaDeLip33TYr2ZII9GS972csaHgZsfnhSyJPLSdd60mq1omzd6jYQze63wug4Thydbl3xVsgHBwcpFAqk02lKpRKjo6Nks9m40tvw8HAcN5DP5+OWp/Z9gTiv3HaEGxsbi+fSk9hgQhv9n+zqZu+p67qxZ2Eia12FXVHGoyKunFIYYzhw4AC33XYbu3btolgsxvsuu+yyCY+fyBK0buukaE9lZU+X3//9328IPkvOiY+NjcUiaNPIkqKebF2aLLVqc8Kbc86txWvLsDYLue/7DAwMkMvlyOVylMtlhoaGcF2Xzs7O+AGgVCoBxPPhULfKrai6rhvPhdt8d1seNonjOA255tZrYCPaHceJ59ft/QYmnMJQUVcUFXHlFKJWq3Hw4EG2b9/O3r17GRwcZHR0NN7/O7/zO5NaedA4n30s1/iJsmbNGi666KJxzU6sW90KtRV0O5dsX8l666VSKW5DaqPak41WbPCZFbrR0dEG17rNFe/v78d1XTo6OvB9n8HBwThyPZPJUC6XGRkZieMJbM65tcqTkeqpVKphvtzmuTeLrU2Hy2QycXBhMh5gooeoZmFXa11RVMSVUwDf9ykWixw+fJj9+/fT39/PwMAABw4ciAUawlxta8FBXbSnM5/dSt71rneNyxW3Frj9mcwdt0KYTEVL1lO3ed/2mObmKVZkbSpZLpfD9/04/cx1XQYHB6nVanR1deE4DsPDw4yNjZHL5RoKw1irPJPJkM/n4weIZOCbnS/P5XLjxHyi/HHram+2zu1Diz0nGTjXLOwiMmnAoQq7cirT+tJUijJL2C9sW2Z0eHiY0dFRjhw5wr59+zh8+HB8rBXr2RDpY3H11VfT09MT52Zbd7m1tovFYlxBbWxsLBY5a23bvt9WzGq1WtxyFMIpAmspWyvXllK15VdtY5TBwUE6Ojpi17mtr26FuVwuUygU6OjooFQqxW5y6zq31eHK5TKjo6NxlTj7Xrb+fFJYk3PgSax1bufMk3ny9vNawU6eY9dtnnry1fzQYB8EkucpynxGRVyZdyQjxa34WRE/evQohw4dYv/+/QwPD8fnLF++vKUFXabiWFaf4zj80R/9Ee973/vinG5bgKZUKuF5XmxdW++AFUUgFmV7D3K5XJznnc/nY+HLZDKMjY3F5WWtO9zmiGezWRzHYXBwkGw2Sz6fZ3R0NBbyQqHA6OgoAwMD8Xy4Hdvw8HAceW7nw5MBeVbM7T13HCeukmePs7XYrTA3i6oV7WTOfPIBxlaqs9h9zddpFvakdyZ5Tyc7X1HmMiriyrwg2Qgk2Z4zOYc8OjrK4OAghw8f5sCBAw1FXq6++uppv890t5+Mi/aP/uiP+Lu/+ztGR0fjqO9UKhWLbrFYbGiDakU8aUVaMQNi13apVCKfz8cu9VQqFbcUtfnlQLzdCrF1dXd1dcX3Mp1O093dHbv4q9Uq+Xye7u7uhntu58FtlHoyUM9+BpvWZ9eTUwnVanVC69zeXyvWycwBW7DH3pNk6dmJaBbopKgD4yz25vuswq7MVVTElTlJ0mqyUdfJ7c19uUulEgMDAxw8eJBHH32Uw4cPN1hc73nPexq+qE9GgJPWW/O2qY5PUigU+Ku/+ive8Y53xGJaLpdjF3qyClrSjdzsCrZWORBbyqOjoxQKhdh1bYPGbGS4rXmetHIzmQy+7zM0NBRb5aVSif7+fnK5HF1dXQ3V13K5XCzmNvDNRp1nMhnS6XSDmNv3tg8Tdr35gWwqd3szSXe7fSXFfLI6+PZ+NYtzs7U+UTBe8kGh+f9hOv/vitJqVMSVttIsyklry64nLTFonAsfGxtjeHiYI0eOcOjQIfbt28fevXs5cuRI/B6pVIrly5c3FBiZjgDP9Jfwm970Jj7xiU+wc+fOBmtyMiswaTXal3Wr23UbGW6LvNiftn57qVSK121Klw1Osw8LVphzuRzGmHguPJ/Pxy76kZGRuHJbV1dXQ/S8rdhmm8okpz3K5fK4PPt0Og00TpPYjm12TBMJenJ78p4kH96a7+tUTOZtSQbGJefZmx8GJhL3iTje3zd9GFCmQkW8xRw4cIBly5YB8JKXvIR77rknthKMMVxyySV87WtfA8JmHDt37mw4/8orr+Rzn/scAE94whM4ePBgw/7nPve5fPzjHwfgvPPOa3AZA/z2b/82H/rQhwA488wzx43v1a9+NX/2Z3/G6Ogo55133rj9b33rW3nHO97BwYMHJ8yr/tM//VNe+9rXsnPnTq666qp4u/1C+8AHPsDLXvYy7r33Xl74wheO2//Rj36UZz/72dx000289rWvHbf/7/7u77jyyiu54YYb+MM//MOGL1ZjDJ/61Kc4//zzue6663j/+98PEFtxlUqFSy65hP379zM0NBSf57ou5557LgD//d//zbp16/jSl77ERz/60XGf72c/+xlLly7ln/7pn/jUpz41bv9NN91ER0cHH/vYx/jSl740bv/dd9+NiPCBD3yA//zP/2zYl8/nufnmm+P7aLur2bKoxWKRJUuWICLs378/tmDtq6uri6uvvpparcY3v/lN9u3bFwuG4zisWbOGP/3TPyWTyfCRj3yE3bt3NwjM2WefzV//9V9TLBZ5y1vewr59++IHGxHhkksu4cMf/jCu6/KSl7yEI0eOxPuMMTzlKU/hfe97H9lslmc84xkUi8UGl/cLXvAC/uzP/oxyucyFF1447kHkFa94BW9/+9sZHBzkt37rt4BGwXvjG9/I7//+73Pw4EGuuuqqcaL6tre9jd/93d9l9+7dvPjFLx537//sz/6MF73oRWzdujUucZu8xvvf/36uuuoq7rjjDt785jfH72/5+7//ey6//HJ+/vOf80d/9Efjrv/pT3+aLVu28KMf/Yj3vve94/Z/7nOfY+PGjXz729/mb/7mb8Zd/+tf/zpr167lq1/9Kp/4xCfGnf/d736Xvr4+Pv/5z/P5z39+3P6f/OQnFAoFPvnJT8bfIUl++ctf4jgOf/M3f8N3vvOdhn35fJ7//d//BeAv//Ivx5UjXrJkCd/73veAMHviF7/4RcP+NWvW8PWvfx0I/x9uv/32hv1nnXUWX/ziFwF47Wtfy7Zt2xr2n3feefHf08tf/nJ2797dsP+JT3xi/Pd49dVXNzyEAzz1qU+N/97t716S5z73ufzJn/wJAJdffnnzreGlL30pb33rWykWizzzmc8EIJ1Oc84553DZZZfxzGc+k0KhMO68+YCKeAsol8t84xvf4FOf+hQHDhzgwQcfBGD9+vUNwUmO47Bhw4b4vPPPP58VK1Y0XGvjxo3x8pYtWxgYGGjYnxTmLVu2xBHLlvXr18fLF1988bixnnbaaUAobBdffPG4L8qVK1fGnbIuvPDCcef39vbi+z6pVGrCh4BFixZRq9VIp9M87nGPi7fbL7Oenh6MMXR0dLB582aABgu5t7eXbDZLb29vvD9p+WQyGSqVCplMhjPPPDNOz7KBbfv37x/34HPllVfS0dEBhKlR9n02bdo0bvx27ravr4+zzz573H5r+fX19fHYxz523H7L8uXLx+237233n3XWWUBYROXee+9FROIUrmQlM2uxep7HwMAAlUqFdDpNV1dXg6Xa1dXF8PAwlUqFnp6e2D0PxK1HbTOTZcuWjXM5L1myJG5LumLFirjRifWG2AeMUqnEsmXLxnUyy+fz8Zz+6aef3jDnDMTd0To7OznttNPGpX7Zkq+O47Bq1aqGaxtj4rl73/fjB+XkQ4KNzk+n0w1/V/Y97Je067osXbo03m9/92x6WyaTadhvsWVjM5kMfX194/bbqnaFQiE+P/n5bExCKpVi0aJFDe9tx2Wbz/T09Iy7vp0ayeVyE+63XoJMJkNXV1fDvmw2G3so0un0OMGycRT28zXvt14Ze76918n9Fpt+mCT5u5/JZMhmsw377b2117feGUuyVLL18Ey2f6KyyvbvIPk7Pzg4yLXXXss//uM/8sEPfpD3vve9cWXG+eT9kPmWP7llyxZz6623tnsYAOzdu5dPf/rTfPazn+XgwYOcddZZvPnNb+Ztb3tby/tSH+v/aar9J/t/3Dxv2HzN5i/rZpd1czBR8su7WUisGz3pLk7Ol1qXrI2aPnToEI8++igPPvgg999/P9u2bePRRx+Nr79s2TL2799/Up9/Nnj961/P5z73udjNnM1m4y9b+6WYy+UoFArk8/l4Pbmcy+XiL0AbZJbsLmavbfum23Wb2mX/H9LpdCze9tjkF7glKaBWAKH+u2Hf217LFp6xbnL7/kDsQk/mhCcfUOwUg/19SBa1sTS7zqf6G0xO3UyWijZRIOHJfLkn/06alydisr+jqebhm9+vFduPl+nco1Ydc7LUajVuvPFGHvOYx7BmzRq+853v8N73vpe3v/3tvOpVrxr3MNIuROQ2Y8yWifa13RIXkauAfwRc4HPGmI+0eUhTYgtRZDIZbr75Zj784Q/z3Oc+l7e85S089alPjb84jvUH2nzNVtL8yz+d+V/75do87uYo3oneK/lllzxuoi/IZtG2c7rJYKLmoLWkeNs58KSAP/LIIzz44IPs3LmTgwcPNozh+9///nRvW1u59tpr8X2fL37xi7FA2c+cTqfjuua2mUhSxO0223XMzl3bPO6kgNu0sqTA23Vrhdr5ccdxYmteROKIdvs7ZK2rZF355vrnyZaoyRxvO/8N4wXbkjwGGOfVsg8Iybnw5PH22s3BbsnfweZoePs7m/wdbKZZ1Kcr8sfaP5GwH+vvL3nt5M+ptp2IOJ6MkdDqzI4k0/0skx3nui5PfvKT43XrTXnjG9/Iu9/9bl73utfx5je/mbVr17ZiuDNCWy1xEXGB+4HfAvYAtwAvN8Zsneycdlniu3bt4t/+7d/4/Oc/zyte8Qre//73U61W2bNnz3H9B5/sL92x9jdbyMezPNn7TPbkn/yCmezLZrJzkoFrSas7WVa0uZKZtb77+/vZt28f+/btY/fu3ezatYv9+/ePm3p4/vOfP25ucK7z6U9/Oo5YT4qPTc2yrkRrbVuL3Qq6dVVaYbeR4s1WunU/WwG3AWZW2G3+thV5u2yMabCgrRVu1+1UjB2zFUsr7EnBthZ+UrCaBTf5wGd/R5qFaKKAwOZAtIl+zyeysicS5Il+x6eqApf8e5no72eqv6ljMZHIT7bvWBzvw/50t50IrTR2TlbTjDH8/Oc/51Of+hTf/va3Wb9+Pdu3b8dxnLjh0Gwzly3xi4EdxpiHAETk34HnA5OK+GxgvyiCIOAjH/kIX/nKV7jvvvuAsInG2WefHafsnH766Q3nHo8bfapftonKU57sE21y7jlJ8gu22SJPzkc3R+U2v/dE7sJkpLm1uJNNRmzUcjLa3Ar26OgoQ0NDHD16lKNHj3LkyBEOHjzIwYMHOXr0KP39/eMCXCwXXHAB3/72t6d9b+YKb3rTm7j66qt57Wtfyw9/+MPYErQPNM3YVKyk+FqXubXAk2lfEz0ANL9sKpjtuW4j3m3HMvslZo9LztlbcbaV4pofROwxSUG3xyW/HJtT6SZykydFNrmetPibXeIWEWmwspsfDiYS4uZXcpoheZ2JXOZJjiWGU1nVE50/lZu9+W+1+Z41HzMbFvJMudKP58HoWEbNZZddxhOf+ER27drFzp07Y6/Yhg0buOSSS3jCE57ApZdeyjnnnMPixYtnxfU/KZNZU7PxAl5M6EK3678D/H9TnXPhhReaVuF5ngH0dQq9XNc173//+1v2O9JODh06ZN71rneZNWvWGBFp+73Vl770Nf1XKwFuNZNoYrst8WkhIm8A3gD16OpWkMwnVeYn1i184YUX8qEPfWjCtLj5Sm9vLx/96Ef56Ec/ShAE3H///Vx33XX86le/4v7774+r0tliONroQ1EWHu0W8b3AmsT66mhbA8aYa4FrIZwTb9WbT+SyVpS5iOM4PPaxj50yrU1RlIVHu1uR3gKcKSLrRCQNvAz4bpvHpCiKoijzgrZa4saYmoi8FfgRYYrZF4wx97ZzTIqiKIoyX2i3Ox1jzHXAde0eh6IoiqLMN9rtTlcURVEU5QRREVcURVGUeYqKuKIoiqLMU1TEFUVRFGWeoiKuKIqiKPMUFXFFURRFmafMu37iInIIeKSFl+wFDrfwegsVvY8nj97Dk0fv4cmj9/DkafU9PN0Y0zfRjnkn4q1GRG41k7R4U6aP3seTR+/hyaP38OTRe3jyzOY9VHe6oiiKosxTVMQVRVEUZZ6iIh51R1NOGr2PJ4/ew5NH7+HJo/fw5Jm1e7jg58QVRVEUZb6ilriiKIqizFMWtIiLyFUisl1EdojIu9s9nvmGiHxBRA6KyD3tHst8RUTWiMj1IrJVRO4VkXe0e0zzDRHJisjNInJXdA8/0O4xzVdExBWRO0Tk++0ey3xFRB4WkbtF5E4RuXXG32+hutNFxAXuB34L2APcArzcGLO1rQObR4jI5cAI8K/GmE3tHs98RERWACuMMbeLSCdwG3C1/h5OHxERoGCMGRGRFHAj8A5jzK/bPLR5h4j8EbAF6DLGPKfd45mPiMjDwBZjzKzk2i9kS/xiYIcx5iFjTAX4d+D5bR7TvMIYcwNwtN3jmM8YY/YZY26PloeB+4BV7R3V/MKEjESrqei1MK2Tk0BEVgPPBj7X7rEo02chi/gqYHdifQ/65am0ERFZC5wP3NTmocw7IjfwncBB4CfGGL2Hx8/HgT8BgjaPY75jgB+LyG0i8oaZfrOFLOKKMmcQkQ7gm8AfGGOG2j2e+YYxxjfGnAesBi4WEZ3eOQ5E5DnAQWPMbe0eyynAZcaYC4BnAm+Jph1njIUs4nuBNYn11dE2RZlVonncbwL/Zoz5VrvHM58xxgwA1wNXtXko841LgedF87n/DjxFRL7S3iHNT4wxe6OfB4FvE07dzhgLWcRvAc4UkXUikgZeBny3zWNSFhhRUNbngfuMMX/f7vHMR0SkT0R6ouUcYbDqtrYOap5hjHmPMWa1MWYt4Xfh/xpjXtXmYc07RKQQBagiIgXg6cCMZu8sWBE3xtSAtwI/Igwm+g9jzL3tHdX8QkS+BvwK2CAie0Tkte0e0zzkUuB3CC2fO6PXs9o9qHnGCuB6EfkN4cP5T4wxmiKltINlwI0ichdwM/DfxpgfzuQbLtgUM0VRFEWZ7yxYS1xRFEVR5jsq4oqiKIoyT1ERVxRFUZR5ioq4oiiKosxTVMQVRVEUZZ6iIq4oCxgR6RGRN0fLK0XkG+0ek6Io00dTzBRlARPVa/++dqFTlPmJ1+4BKIrSVj4CPCZqHvIAsNEYs0lErgGuBgrAmcDHgDRhYZoy8CxjzFEReQzwKaAPKAKvN8ZotTRFmSXUna4oC5t3Aw9GzUPe1bRvE/BC4CLgQ0DRGHM+YZW+342OuRZ4mzHmQuCdwD/NxqAVRQlRS1xRlMm4PupxPiwig8D3ou13A5ujzmtPBP4zLAEPQGb2h6koCxcVcUVRJqOcWA4S6wHhd4cDDERWvKIobUDd6YqysBkGOk/kxKjv+U4ReQmEHdlE5HGtHJyiKFOjIq4oCxhjzBHgFyJyD/C3J3CJVwKvjbo23Qs8v5XjUxRlajTFTFEURVHmKWqJK4qiKMo8RUVcURRFUeYpKuKKoiiKMk9REVcURVGUeYqKuKIoiqLMU1TEFUVRFGWeoiKuKIqiKPMUFXFFURRFmaeoiCuKoijKPEVFXFEURVHmKSriiqIoijJPURFXFEVRlHmKiriiKIqizFNUxBVFURRlnqIiriiKoijzFBVxRVEURZmnqIgriqIoyjxFRVxRFEVR5ikq4oqiKIoyT1ERVxRFUZR5itfuARwvvb29Zu3ate0ehqIoiqLMCrfddtthY0zfRPvmnYivXbuWW2+9td3DUBRFUZRZQUQemWyfutMVRVEUZZ6iIq4oiqIo8xQVcUVRFEWZp6iIK4qiKMo8RUVcURRFUeYpMybiIvIFETkoIvdMsl9E5BMiskNEfiMiF8zUWBRFURTlVGQmLfEvAVdNsf+ZwJnR6w3Ap2dwLIqiKIpyyjFjIm6MuQE4OsUhzwf+1YT8GugRkRUzNR5FURRFOdVoZ7GXVcDuxPqeaNu+2RrA2nf/92y9lTKHWJzz+NE7LqOvp9DuoSiKopwU8yKwTUTeICK3isithw4datl13ZZdSZlPHC3VuOgjP+NP/1Mr/ymKMr9ppyW+F1iTWF8dbRuHMeZa4FqALVu2mFYN4MGPPLtVlzou/MDgOgLA7qNFBktVhsaqDI/VGB6rsaQjzZUblgLw/u/ey77BEkdHKxwZqXBktMIzNy3nIy/aTBAYznrvD6gF4S3xHFjameVVjz+dN13xGPzA8MVf7GRZV5Zl3VmWd2VZ2pkh4zU+vhzvDZVxWxqvICIYM9URYBIHTLbPmOi9RGjagDEGPzAYIAgCAkO87PuGSi2g4gcMlqocHC2x69AINz1wmJ/uGCCI3ufrtx3gqWc9wtMfd/q0P/sJUR6B7T+Ah2+EQ9tg5CDUSuBXIPCp36zmOxF9bvv5k3deJlpu+jnRefHqJPtmgll4i2MzJwYxB2nhfdFbXMdJwR/cNStv1U4R/y7wVhH5d+ASYNAYM2uu9HZiBRxgzeJ8w5NMM+9/3jnjtiUF8F9eczFHRiscGSlzcLjMgcExlndnERGOjpb50HXbxp3/58/ayOsvX89gscrnbnyINYvyrF6cY82iPCu6s3iuM+59wvWmccRLMulxSamQWFtk3DnJ9zNG4uvH26BBuESkfh+NAxKJuDEYE55ngKXdOdYHnWw5rY+nnbOS1w+V+b9t+/jUDbsAeMPX7uHhmRLxh38BP/gTODBhgoaiKMpJM2MiLiJfA64AekVkD/CXQArAGPMZ4DrgWcAOoAi8eqbGcqohkZg5jnDpGb2THtfXmeGuv3w6B4bG2D8YvvYNjnHB6T0A7Dpa5FPX7yBIiK7nCP/w2+fx3MetZO9AiR/cvZ/1fQXW9RZYszhPyp18BqbBuk5c0zRvMxPLv9Vox2nYOu76xtQF3jRdxHMcMAaDxKLuOoLnGDKpHIvzGdYsLvDYFR287etbAXj7l27kE9dcNunnOm4CH775Orj3W02fwSTWW+ZQUhRlATNjIm6Mefkx9hvgLTP1/koo9t25FN25FGct6xy3/9zV3Wz/f8/k0YESu4+W2N1fZPfRIhuWh8fes3eQD113X3y85winLc7ziZefz6ZV3ezpL7Knv8T63gJ9nZn44SJ874nHNJHQTybysRXfYMEnry3xNccJezxmBxMYjCfRNIaL5zpcftZK8qn7KFYN3902yIeGS3R25ia5k8eBMfDlF8DO/wNxAAfEBTcNrhf9TIF44HjhMY6ExxEkbkYApgY1625PuN1NkLhPyU+beEgwiRuYXLHnTPYfNG1OJd+pPlCFnEr/p23GmT0n97xrRaq0lpTrcPqSAqcvGR+pfdWmFdz5vt/iocOj7Dw0ykOHR9h5eJTFhTQAP7h7fyzyXVmPDcs7OXNZJ3/yjA305NNU/QDPkSZxn1zoJxP4qcRdRKJXfNUGUQ/iefTwISQIDOIKIi7X//HlXPKR/wPgT75xO/90zRMbxndC/M/7IwH3wlcqA14WvAyk8uFyugBuJtxnRd1NEQo+NMSbBgEQhHfC+OD74Tbjh9vtnHps3Cfm14OAWNAJGmML6rerfkfFgJHxc+lyLM+BiuDJowJ6SuGmZu2tVMSVKenJp7ngtDQXnLZo3L4XXLCKx67o5MGDIzxwcIQHDozw43v385fPPRuAv75uG9+5cy9nLu3grGWdnLW8k7OWdnDxusUTiuV0BN6Ks12eXNjDdTcS9SCaJxdHYt3qzmfj6/9g+wC/2HaQyzYuO95bVOfQdvjlJ0LLW1xIRYKd7oB0DtKd4XomEvFMAZxI4N0UOG4YEOO64Yd0UqHV7USBiEHVfnLCDxSJuqlFlrsdSFAXarHH06gTxgq8PckPBdxa7ULiGk60j/FaIxPMmzS6AZIHT+cunhosoI+qTICbnrW3UhFXTpjejgxPOrOPJ53ZN+H+i9ctplipcf+BYb59x15GyjV6OzLc+t6nAfCZ/3uQ4bEqG1d0cfaKLtYuKTTNh9cZ70pvFHZIWO0JYY/F3AmD6aygE06dU0g5jFZD9/S37trN6csKrFnccWI35HvvCC/qpMBLR8IdiXa6C7JdkM5DphNSOUgVQgH3MqGoW4tcPPCiJ3nHoy6KDSocPdFEYo4JhTnwwa/RYJHHYiyR2Evowo8tdyf8aS8fEIlzkLyp9euNi3aXJpdJvKNxvON2qdIppyhqiSunAldtWs5Vm5YDoeDuGxzj4HA53n/bI/3877aD+FFkXT7t8uxzV/C3L3kcADsODrOqJ08uPXFG/7GEvdkVb0XdEXAdhyAwvPD8lXz55j0A3L2rn9sePEpXNk13/jifpA9ug12/CgXY9SJxzoVine6EbEco4qmOcDmVC93rbia02N1MKPz2Cd7LABJ+GZggfDBocH07oXhbTTX2ycTOnQeRYAd1q5sgcrHbe2L/Mckb1eRut9Z6ZJ2LU9+O1AV8wjS2k+Sk5+0V5SQY91B6HLg6J66cYogIK3tyrOypB4999ne3MFb12XFwhK2PDrF13xDLukIXtzGGF3zql4xWaqzrLXD2ym42rujkSWf0ce7q7infJ/xZ32bnyIF6JH4k6u98xmNjET84UmHbwUFWLclz7uoesunj+PO44WPRAJxQcB07F56NxLwjtLwz+dA693KhVe5Gx7mpcB2pW/JCPfjNEAl85CqXKGDORHPdgR+JrNso3vEraUlHP2NxlsaHgXju3N7U6B+TEHw7T5608u0xU4pvw0VP4hilpcz1B6aTEdSZvNZkyOzVUVMRV9pKNuWyaVU3m1Y1CnNg4GMvfRxbHx3ivn1D3LGrn+/d9SijV9Y4d3U3o+Ua7/zPu9i0qptzo9eiwsTWc2PgW6Ood+Tq5wxV4NBQmb0Do3Tn06xdUiCdmkZdP78K275Xnwt3vciqjoLZ0tYij6xvLwdevh7wFot9JhTcdAGCWij6xo+2RwLqZhsD1RyvblFb17pI9CUSCWtgrXHreqdurWOD2aAewR79E4t7IuAttvpN4jrxna5vH/+/MH7VTLJvQlrwxTvXhUppD6b+0Fis1tg/NMa+gRKPWdrB8s4cDx8Z5V9//TDDYzXKNZ+qH1CtGd5y5WM4f81i7th9lI/8cHuD9+9vX3oe62Zp+CriypzEdYRnnLOcZ5yzPN42WKxSi9zB+4fGuPfRIX5wz/54/+pFOf7q+efwlMcuo1TxKdd8eiZwizeLutUTAxwerVKq+vSPlsmlXPo606Q9b9K5egB2/BRqY6GguimQdN097uVCd3kq2zj3nUpHkeuRsEs0L53uiH4WwpG5ucgijyxviVLRJB0JeFAXZidVd39b0Q4C8LzJBSxpXTf8pHGdxLpjN0n95k04x91klcfflZLYMEHEfMMxJ0MrrjELVptyDFr/8GUwlGsBWc9l39AYf/vDbTxwcIT+YiU+5p1P38DV5y2i4tTYfrhKZz5NLpUhmxPSrkM6W4BUls6uLs5bvyIKqg3Hm8+1IF11mqiIK/OG7nw9WOQxfR3c8CdXMliscs+jg9y9d5C79wyytDN0x1+//SBv/rfbWbM4x7mRpX/uqm4uWruYbJN1nU05lKLgtqPFMsWxAD8IGC1XyaQcOrOCK4LnCo4zgZvsji9HC04osl5kjbuZMEDNzdbnv710o5vdSYUC5nqhtQ7hceJE8+GE32Fetj7fne4Ig9eCSijk6a5wu18JLXiIHii88e51qIt80vUtQd3qDjckPmBSxGkUbkPC/W7Gb5u2m53E/LuitA6DYffREtv2D7N9/xDbDgyzfd8wL96ymt+//DF0dbgcGoOLz1jBmiV5VvXkWNmd4/QlOfBSnLUyw7/9/pMnvf4ZyzO85zlLGjeqO11Rpkd3PsWlZ/SOq1y3cUUX737mY2Nxv+7u0GL/v3ddwelLCvxs+0G27hti86oeVvXk2HFoFIChUpWBUoWqH1Z9q9QCKtWATNql4hucwOa+R/PvxkR54ZGV7HogqSgv3Ip2JhRV62J3vNCyRsL0MS8b7gtqkVUezYsjodXr5cAvh3PiqVxYi10EcovC96+MhqLspiHbHV7fr0SvsfpNETe6dvSw0TjHwDjLOxE/0JArPtGxrULGLUxy3FSeheN6I2VGmd2HssAYHjlaZNu+IVzH4elnL8MYwyu/eCuj5Rop1+WMvg6evHElm9YsATdFIZfiy69vYcXGWUZFXDklWddb4Pef/Jh43Vrspy3OA/CLHYf57M93jjtvZKzKQLnGcKlGb2c4d14JAjLGxXPDqm9VPyzlKgJydCdOeZi4ApsTpYe5aXAiq9v1IlF2wn1eJrTOvWx4nNWTdJTaZoPZxISiXhuLxN2F8nB4XqYrXPYr4fUynYBAZSR82eukC9FYvDD4LaiF+eaBn5grnwbJ+WtrXTvNaW8T0BA0l9jWsD/hVj8ZbZ3zVvxcH9/85Qu/2Mn/3X+YbfuGKFbC6aVzV3Xz9M1rcIAPvvBClnZlOKOvg7Q3G1by7D0kqogrCwJrsVv+/Nln85Yrz+CevUP81527+c/bHgWgVDEMjlT4xE/vZ3CsxsaVXZy7qpvNqxezZW0P3bk0flTaVYyB7WFP+iAKJhNxESdVL7FKJOCpdBRx7tXnrvFDq9jLhqId+OExjhMFuHVCtVgX8OpoKMqpApT6ww+S6wnPLw+HYo+Ex6fy4XX8WrjdH64Ltjh1d70NgGu2zC2Tzpk3R7knts2EhT7Vl6IGrJ0Y8+i+GQN7B0rc++gQW/cNsvXRIQ6NVPjOm58IwM5DI/h+jec/bnlYd2JlF+t7O+Lf+SvOSri7p/vgejKoO11RZp6efJrLzuzlvNXdsYiXfRgq1zhjeSeHBsvc++gQP7v/CPAQF57Ww3/8/hNJuQ7/eetuVvZkuXj7j5C4VrmDcTwCcRFJIa6H2LKruFExl8il7UZBb1a8U5komDwKVvNyofi6Ue54eSi01FM5KB0NRT23KPwgxaPhfLktIOM4YcR8aSiaI5fooSJfrwyXJPCj8q3JKPYJItDj7nORSz7cmNieOKY5vzy2xhPib2ne1mBRNz0MTGltT7Fvzlvpiv3/M8awfyj823vyWb2kXId/+J/7+eIvHgbCUtEblnVw4drFVHxIew4fvPrcNo57ItQSV5RZoyNXD5jzgVKlxhPWLmbjxYtY0Z2mWoOHDo+Qch0qtdBV955v3U0tMNyeuYNugaoRCISME1raxk1hvAw4KcQEiJtCJCqrGs+Jm6jMahRB76SibYk/y0xnaHVb67p0NNyfWxwK9NhgKJjZnmhePYCxodDNLk6Uk55ttLoCPxT5oBpeY1xkuNMozJY4LY1kwv2JCeRkwj9umzN+27jrjLv4NI45UeaP9TprtOD+PnRohO/cuY+79wxw995BDo+GUeLff2sfm1Z18eRzH8Oyvj42r+rhrOUdZLxppH4uEFTEFaWJ0XKNkZpPpVajUkvTk0/xxDN68USoBYa05/DrP3sqWx/ew6JvjODjUAUwQtZ1qYjDr3cO4eY9OnscenpzLE37pLNpRDzEcRHHI66wJlDP7TZh8Js/Fgrz2FAo7pkuKB6pW+BWwB03CmZzQ2EuR27zVD60zJNfsLVKaN3HEexuFGjnJubhT/ALudmVPs6Sn2obieVggm3KqcKhkTLb9g1z76ND3LdvkFc9YS0Xnb6I/QeO8OXr7+QxfR0864wuzlm5jLNXdXNmdw1K/Vy4FC5c2gUEUB2C6jHfqr3YwNNZQEVcUQg7nNUi67JY8RmrBpRrBt8YaibADxxc18FF8H1Ddy7F5dmHo3MdCm4ak8kSiEuNFJmMx67hKo8eHaL4YIV+c5RXXJZi87oO+os1DhwZZt3yXnLpNKF7OqqR7mbC1DE3E1nJPhR6Q3c6JopIDxIC3hNa9dWxMKBNnHBbsuxjrQK1UmiBO26U7pZOuMSnIJmONpWoNlvTknidLFPNtY8bzwTja9mDgD5QjGOSe2sw7DpaxBFhzaI8ewaK/PY//5rDI1HZZYH1vR0MVD1I5dlyZpZf/MUK8imVpONF75iiALmUw3A5dJVXagGj5VpkifuYwAvru7thqpXBhL3JH7ohbBpqwBGHwHEwuGQzaR6/fgmPL/QxTIE95RyPDBtWL+nE9dLcsXOAT9+4iyppli3uYd3SLtYu6+E5m1fS1ZkPg9HSBRgbCOfBa+Xwle0ORbrUXxfrpIA7XnRMJJxBEAbG+ZVQvNMdoct9MoKg/uAQ1Ggs13oSTCTwJAV+sn1NDwLzKBBroWGM4Ru37YkCz4a479Ehhss1fu8Jp/OB529i2eI0T9iwio0rujhnZRebVnXTkanLTzoFs9f369RCRVxRgMUdaYbLJQDKVZ9StcZYNSAITGyh+wZcY3AdJyzduvdWDFG/dMfBcTwCL4WRFL64uI5DZy7HxkUdbDy9M6yb7ghb1i/lnZ3dPHBolPsOVbhl1yA/vO8wz9h8OsYv8+93HOaXO+7jrKUFTluzhnN7qpy2dBFeOh8KuAnCqHTHCcW9MhIGrGW66kLn18LtsWs9O/EHt0Vi/GrdzS4Suu3dyEtgo9mb+4zXL1K/1rFc6dO17JsZN1/ONNZp3D7uesc45niYdw8YJzbewVKVbfuHuP/AMFsfHaKnkOZPn/FYBPjHH9/HQKnKhuWdvOC8pZy9opstaxeBXyMFfOyF5zRezK+d9KeYFU70/7Y5gHSGUBFXFGBNT45HjkQi7geUxnzK1YByLSAwhGllcT6zCXXuyI7wZHGw1doc8Qhcl8DNUsMN/8BsMFt0XE8+xRMe08ETNqwJL+dlGChW6SpkCPwKNUnRPzzCtTtHcH61lzRVatkl3PaeJ+P4VX69t4LxhjirL8sStxReOyngtUrCtd498ZdJEIQFZPxKKKS26MxE0eszjUmK+WTpbE3H2POAhkp0yf3J6yvHxVgt4KFDIxweKXN51Gr4bV+7g/+7/1B8THcuxZM39MV1Cb7x2s30dWZwm0XP1i1YSIiEf3uzgIq4ogBnLuvgxgePAlDzDRXfp1ozVP2Amh9Q8wU8l8CERdQIDDJ6CEQIxMGxXcW8FI6XQhzBF4caDq64iJsJ9ztRZTcbxOVmAaGnswD4mHSeV16Q4RXn91JJ9/DI7l1s64cjZQenOgpuio/+9AFu39VPN6MsyadYunQZTzxzKW9/6plQqzA8PEBHLoMkhT1JrRwGuBkTpbplZl+4k7Rq7ny6TCTqJyz08+ABYYrPVgsCvCg24gf37OO6u/ezbf8Qjxwt4geGfNrlrvetxRHh8nPWsmndSjYs72TD8k6Wd2XD9MqI5b0dM/5RZp5W/X9qipmizCpnr+yKl2s+lCoB5VqNSi2gGhgcBN8YXGPACDK4GzE+gbjh332yVrl4iOvhOg6+l8F3HFwBcSKxspZ5nF8OYaR6LUxF88uQW0y2OspZy3s48zF9UB4i8CtIupPPvOpCtu/ayyMH+tna77D90Bg7D4/GLvQXfuZmDldSnLm8izOXdnDm0g62rF3MphWdYcGYwA8tbi83veC2yTATWclQ/yKcwN0924I9ERO9f7vHNAvsPlrkpp1HefDQCA8eHOHBQyPsOlrk1j//LbrzKbYdLHHXoyNsWN7NVZtXs2F5J49d3om4YQOdl1yyrt0fQZkAFXFFAc5eWXd9BSZ0qZf9gKpvCIKAahCQNi7GhJnS3v7fhAcbImtccJyo8UlUF128PK6ALy6+H+CmXYRINN10UwR3lDMe1GKLXfwqku3CmBqmVsak8xhx6c3W6FvbxZPOWhH1ICcU5vIQRhxe8aSzuf/gCA8cGOF7dz3K0FiN371kJZueuZ6aH/DCz97ByiXdrO0tsK43z7reDs5a1jFhx7f6TQkSwW7+xJHix8UkOeLTCXBTJqRc83nkSJFHjhTZdbTIzsMjPHhwlA9efQ5nLO3kxh2Hec+37sZzhLW9Bc5Y2sEzzlmOHz2A/cHTzuQPf+usNn8K5XhREVcUYO2SQrxcAyo1n1Klhh8Yar7BmLBuuriGIDDIgbvqJ4uDwcGIhxC5pR0v1B4vg+s41Lw0Ph6uCIIJC62kC4AhrNLmhwFo1dFwfrsyGqeDydgA4rqQ6cAYQ1AZxYgHXg4JTFjCPJp3lEwXr76sJx6aMYZDg8OYcgnEYZQsfT2d3H9wmJ9uO0DVD7/A3/WMDbzlyjM4NFzm/d+9l9WLcqzpSbO6O8Wq7jRrerJR9zeJ8sptuVab3w4TuxCbq7BNMtedDHY7JtOJdE+MZ8KgOObdQ4ExhiOjFXYdLbIrEupHjhR5xSVruPD0xfzywSO8+ou3xMd3Zj3OWNrBaJR18YxzlnPxusWctjhPyh3vgZF5dj+UEBVxRQEKmVTD+lgtoBIYyn5AzTfUjA841AykDMjBrXWnseOF5VYdF9eRsPGJLaJiQMTDcxxqIqGQ4yAS1Ud3ol7fJrLGkfDcymhYrc2vhq90B4gg1SKuGEy2I+6B7leKiO8jmQ6kyT0ufpWlmQByBUgX6M4In7/mIgBqfsCjA2M8dHgkfog5PFJm+6NHufG+YWpRdboaLh99yfk8//zT2Lp/hE/8dDurF+VYvSjH8u4cy7oynLWsk0KmRfPqxxPoZpqKw5wwU4n7JOI2pegdvyDWgoCHDo2yb2iMfQNj7B8qsW9gjN86exlP27iMBw8O8+xP3thwzrLOLE87sxtW5tm8LMMnX7KRNYvznLa4wKJ8qi7MtTKLM7A4kwJTDZ9U5xXz7AFDJJyymgVUxBVlAmo1Q6VmqNUCAgx+5EEOonxxOfoQ4ReLgxFBHIfAhBZ52KI0iBqMCLgegoQFZUyA73h4ycYjxoSR4bWxsMqaPxael8qHRV7ECbcHQZgT7qbDuXMAv0pQK2O8DMZJQWSZi0go/tVivZtZk+h4rsNpS/KctqTukt+4xOV/3n4JgREOlwx7hqrsGRhjy+mLwHEYKFV44OAwP7v/IGPVeiOJ/3jjE7h43WJ+dO9+/uEn97OsK8uyrgzLurIs7czw3MetpCefZrBYpVT16cmnxvV1jzkZ13lDYRiYMqo9uW2q7RPuP/bxxhhK1TBAsjufwhjDf9y6hyOjFQ4PlzkyWubISIUrH7uU1166llK5ytX/3w3x+Y7A0s4Mj1vVAUGNVd1p3vvMs1izKBf3vc7a8qNBjSU5l+duWlofQDATSj0PAvnmBCriijLruBLmggNU/YBq1afih/3EAfzAkHZDcZGRA+GBjhMGujluKOTi4nrZsKGJ70M2Gx8njofnetSMoeakoz8+AYKoaUkQdSQbCn+aIEwBswJcGQFM5IaPqBZxHAfS+dAyN1FZc7+GVEYRx0EmEPAGjKmXYxUHvByO67E0C0sXwQWn1w994mN6+ekfX4ExhsMjFQ4MjXFweIwNyzsBKKQ9Vi/Kc3B4jG37hzg8UsEPDFdsWEpPPs1Xb97F3/xwGwD5tMuifJpFhRRffs0lLCqk+Z+tB7j54aMU0h6FjEtn1qOQ8XjmphW4jrB/cIyRco2M55D2nPhnPh19lZ1kYZhKLYgyEgzlms9oxUeAtb3hPf/5A4c4NFymWPEpVXyGyzWWd2V5xSWnAfDaL93Cw0dGGSxVGSxVqfqG5z5uJZ98+fkI8P9+/AjD5Ro9+RS9HRl6O3Kkch2Q6aAzA3/7iieyrCvDyp4cSzszeAm3dy4Dv/Pk2UlbWlDM8xREFXFFifBcB79WF+yxWpReZsLyq4GBgCAsd14egqhDl3G90CoWl8BNh/a5IUzdEknkiIeFYVxx8IMaNTeNZ8XGQFw73URCXS2G7+HlwsC1WjkUd5sOVo1KqWY6Q1c7kWc+CDDVUYwIJlVADAhm4jnPwA+vY0u+TlXRLYGI0NeZoa8zA9SF5bIze7nszHrLVz8wHBktszgKmrtiQx9dOY+BYpWjoxX6ixX6Ryvk0uFnumvPAF/+1SOUqn7D+z304RUA/ONP7+drN+9u2JdPu2z9q6sA+JNv3MUP7tkf3QuJrNksP/rDywH4w6/fyY07DofPLUEo1msW5/nBO54EwCs/92tuebi/4fqPW93Nf731MgA+fN027ts3lLgP8OSz+mIRX1xIk025dOVSdEevx67ojI//6TufTE8uPWlP62dvXjHZLVdminkeC6AirigRGc+hHIl4NfCp+QEVP6zaVvUDAgIwDmZ4H4IJ+3lFlcwCx8N1XYwjBOLhWHdaHIEeBYO5aZxo7tu3aWupqO1oOh+6yx0vfNXKUQ63A+WoYEbKur6DRKvSRred1Eph8Fy6A+M4BPE0csLVDqG7vTYWW98zkSvuOsLSznq1uI0ruti4omvS4//46Rv446dvoOYHjFZ8Rss1Rss1HCcc88svPo3Hr19CpRb+35SrQcN38CXrlsRWuYkevDqz9a+5x63uJpsKH6hSruA5TvQgEvLKS07naRuX4bmhlZ9Puw3j/6dXXoAQPjjk0i75tBfGQUT87UseN+X9SF5LUVqBiriiRHRmPYbGwnnEWgCVyK1aiSbETRBWbpMjD0ZnRAFp4kSts13ETRPgEHgZnMCP8sGjim7Wa+emw4hyx8EPwocG11rC1UHIdITiiqnPhScFHerFWlK5xg9Ri0qopnLRXHw4TWCMqbvajUH8CuKXw25qzd3O5gCe69Cdc+jONT6gbF7dw+bVPZOe96ILV/OiC1dPuv+aS6fOdb76/FVT7l/XW5hyv6LMNiriihKxKJ9m78AYAL4fUPHDufEgCKu4VQNDDsHr3xGfY5wwkM04Hr7j4SIEjhAQ5Y1HddVxI0vcBKHl67g4jmACCIIAwcGx5UNT+ahLmRda2ZUiYEJrGepWeHOlNWPCbmWOF+5LICL1vijVcph37niIlyORgHXyxBHjQX15woCyJhoeIhKpY/E+zRlXlIlQEVeUiOWdWe4hnO8MDFRqtSjFLMAPwtrpfhDgHn0gcVYkKI4bSpXr4KSz4Ry6m8Yx0Zx4fHg07x3lVrupDKZWwU8VkGoJcdNRdFotTCuDULBtRTgIhRrqom6plqL59KbtSfwaTlABL4Xxsg2u9tA5cALiGPjhKy4CYz+rFd0oEn+qazdHeo/rLT4JxyoSY49R0VdOUVTEFSVi9eK6+AVBGKkeJALbwBBgcPofimzLerETEYdAHAzhHGngpvCNCa1xiKzv5J+bFRUnTD1zXGqVEl6uG4lFOhu6x01Qj0ifyLUOYclVv9IY+NZM4IcPAOJCKjfO1W4IA9FsgNyUxT9sBbeGzmdOvTZ8q4VzXInXiXLJg2i+YBKOt0CMCr8yD1ARV5SItb35eDkwUKsFVAPwfROKug9iwBnaS12EBWMcxHURcQkQXOPguGn8QAiAWGolDGxrSLUNw9pxHaEG+E4GrzIUHuc4ULGBZ5F73C+HP72mAKlaqfG4ZowJLXWbc54cQtLVHpg4VW1cIFx4QFhtLoiixx0vquA2ww1UjkdUJ6zp3rztGILf/N7hwgTbEttPqAXqJMcdcyxzgLk0lgWMiriiRJy+pN6FKTBRrngtqp8eRTobIzjFw+FBYlPMXFxx8W2VJsfBJcBPpQjrvBHWRY/PSVjnJgAvgwQ1PC9NzQTUalW8fD5yB1Tqomvzud10o2j6kaim8pN/sdo0Mm+KY6i708cFwhmDY6L3iT+nNze/yI/Xim6uEGe3TVQyNnlO87bpPhQo7WNGfl8neVib7IG6xaiIK0rEmkUJdzpQC8JgtloQ9RXHUDUBTmU4PEgcwAVCAXe8ND6CwUUcD0fC4i/GTYcpXxCJbZSL7aRCqzaVh8ookunADSr4QOCkcazV7VorvFKv7pakNhb1A58kx7tWCeervey0u5ZZ69wYg/FrGL+Kj0GcFOJ648q7zmtmynU+rZanxyn8bS9M0u73PwFm9J61/36oiCtKxLLuujgawnSyas3HjyyswA8tYQmqBEj43eBEKWbihZXTovM8Nx1WgCOs0Jay5VUlSjVznfqXixUQN4NTHsakMvgIUhtDbGc0COfCk+tQt8LTk6Q+BUHogreR7seJ+FUkqIHjYNwUQZTl3lDeVZmYBdryVJldVMQVJaIjU/9zMISWeM0Yar5PYAyVIMAZPVQ/IWpcIiIYcXDEQ5wUJgrsEsfDcYUgIKyvbkW0YYrVrZc7FQeMj5vOYwKfWrWKly2EhwV+eFyqPm8P1K3wyQS6Nha+UbP1fiyMCR8abA34qFa7ywSudqYRCKco8wwTPWSPK5k/zfPdE8n0OAFm1CcmIleJyHYR2SEi755g/2kicr2I3CEivxGRZ83keBRlKppFqBaVXa0GUPFDsfKG9tqjQwvccTCOi8ElcMP66cZJY4IaOB6e4wIG3zfhXLbNyo4bn2RCd7eXrgetuRlcUwHAl8hFXhsbP89mrXB3krk3vxq50TPHP0dcG4vn68dVhBPBccJgPCH8UgtMGNke6LywMo8IH0jD39sgMPiJVxA9qCaiI4D4L3jcy5HG12wxY5a4iLjAp4DfAvYAt4jId40xWxOHvRf4D2PMp0XkbOA6YO1MjUlRjoUj9fgka4370R+5MeAO7qofbAwSmdWB62EMOI4TllMVDw+beeXhOw5eUIsam5gwuM340c9yKMTW7e04iF/BS6WoOS5+YHD9SjiHnhTjWjmKSJ9gLtxa0jKFlT4RVsBhWnPozYFwx5WmpiiziP0dhcmt6dhJFicczP3f35m0xC8GdhhjHjLGVIB/B57fdIwBbCHlbuDRGRyPohwTJ/FHW/PD4i7VGgTG4GPwhh5OHOyGlrjrISIEuDhOChEIxCUscOLhuW5UshXAhE8K8Xx4dC03HVrObjpK4/IRN4MjQlCrhBZu0gq37nV3kmA2vxK+1/G40ZMC7mamHQQHjda5I+Otc9Psk1SUGWIy6zppVTdbz6793Y1eYWDn3BdwmNk58VVAst3QHuCSpmPeD/xYRN4GFICnzeB4FOWYeI5Qs4FsQdgLOiAMbqvVDOnhPdFTvIm+CaK66FEkOq6H4zr44oUlWREc10UIS7m6nqkXQ8ENxdhx60VTvEwiFzyD6wjGL+Ob0KKPv1b8yuRpLMaE+53U9IX4JAS8mbBTW6N1nqwKpxa60gqa56wnekyM3d3zyLI+XtqdJ/Jy4EvGmNXAs4Avi8i4MYnIG0TkVhG59dChQ+MuoiitIpVoEelHDU/8mqEWhLni3oh1Fgm2sYkhrNiGhB3DHDcNBKHlHVUHc900BkNgv1bsfLi1vv1KVAwmVV92XDAG1/jgpuIo+QaRnuhLqWbn1qfXVjT8sFH62kkKeJJm63yi+XO10JVjMZVlba1rOHUs6+NlJkV8L7Amsb462pbktcB/ABhjfgVkgd6mYzDGXGuM2WKM2dLX1zdDw1UUyHn1IioBhpofCngooAavVH+INIRR50aaRNxJhWVY7YESfqHghKVYQ+s92muDx/xqKODG1IUdwK8iGLx0Np5vDgPWzMQibSuq2Ypv06FWiQLkjuOc40QFXTkWKtYnxkyK+C3AmSKyTkTSwMuA7zYdswt4KoCIbCQUcTW1lbZRyCREPAA/CNuR+iZsguJWwgYphrDymmDrpocpZYHjghjEzYQBctHcuIjgeKGIx2IV+/iiIDcnssIhUWY1tMrFTYXz48YQ2IA2d4LZMHv+dK3weG49NfH1ZgAV9IWNinVrmbG/WmNMTUTeCvyIML30C8aYe0Xkr4BbjTHfBf4Y+KyI/CHh/901Rv96lTaS7F/tG4NvCBug+KHAuNVRCGe6MULc8MM4HuIIgeOFsWtOGNzmE84PA3hi8PHwDXgSudSdSMAhFF6b122t8qBulbuOYKo1fL+GpHPjiz3a4ydzs090fNKN3waSddsnnUPHjP/C1i/wecGxIsIXwpz1TDOjj97GmOsI08aS296XWN4KXDqTY1CU42FxoS5mgYlSzPwAExgqNROVQjWEbUKc0JXuOPi4eJFJ6bspXBFqThrfhE+wofAbHBF8E+C52boFHAupB+VK3SIOauPc5i61sFFKlMLWwPFa4XYePHWchWBaTdR3XIwJy9MagzFBKAA0WmZgS9Ynvuwn6j2eXNaOZDPKREVRJhVsFeuWoxXbFCVBX1ejoAV+6OqrBgFuUEaMHwan2Qprdk4ciaq1EXYyczxE/NjtjgnnwF3XCRuq4IZ9vdMFqI6FYh74UYW0qIa7jUBPWMniV3FdD18cgsDU+3/bufQoz/yY+LX6PPhsf6EaU/+sJmjcFwmvOG4s1CZxWl3UTbKPXF3SzRQ9yKfqPa6ickymEw0Oal3PNiriipJgeWddxIMAqiacEzcGUuWBaE9kLQogLkbcsLa4eIjjYoIAwtlyaoZQsCPRd0WoSjjH7kB9PtzNhyIMDUFtcfcziIXPSeUxIvjGICb6kgxq4bimY4XHbnd31ubBrbUdexcg/JaP+487kwqpNP1sdtFOaKnb6YqG9qOmPo6JhF5FHji+1C1QsW43KuKKkmBZdz3vOjQYwyIvVePjlQ7W9zlhipmJBMg4HoEYxE3hB4TtSB2HGoKPidLOwq9DVwQ/gJQjdUvUSUG1WE8t82vEdcstsbs8dNebyEvgudKYlnYs4m5ox5GCdqIYEwq37T9upw2mEO1jkZxHD9+iSdTjf6zbXbCJq9J44oIVebWqTx1UxBUlwcruxnakPmHltqAG6cq+xJGRm1wEnLCDmQnAdVx818MPAtxUWEs9riceHe86ThjtLilc2/zE9WCsWhfWILLKk5a4TUOLvkjdqDCNX6vhmmB61dkCP3KjTzP47URpFm/HDT//DKSwTSTqdgiQEPZoY4MFGbvvJ7gXJyTy0CDw9TdKKuEJfc7pkowNPtY8NahVPd9REVeUBEs7G4XQROkvNWPIF8NCL9bGA8LSq+IgOARuirTxqYlLYMJ5cccNXerG+IiTBmNwvDRSreJLJhRxxwstb0xdtJvnt61l7tTHJxKmaAXVcpiO40zjz9mvjptnbzk2bc1G3zverFqqVoCmLeyJHclRnpDIx9unmJtvfIPEMlOuN6cmTkeg47eyr4Z4QBXqUwEVcUVJ0NuZcKcTppX5Uf5yrrQ/caSEddOj/trGCefGA/HACYPdcBxccahhQlGPzkMcPEeo4hLUyjjZjrrlHaeW1SBV9wo07E/gCpighu+mG+q+T4h9EJioVGsrsMF1JiBuzDJHhGIiYYeJrVbTtD5+Jbpm/K80qf9E55nxyybxbkFQ38exRXmCEUCTR2J88UuZZIL7WP9Hx/l/2Ir/8znyezMfUBFXlATd+bpIWmstCMLa6dmx/fXvQAnnW221NnE8AiBwPBwDvhEIDI7n4hgJc8zDrDRsDxSi4DTHSUWtRqM57Vo0993sSp/IovWroVvdTVHzAzx3Cnd1UJ3+vPnxkrS+3dTMvMcMkLRGJ9ON5tIVExnYk4pug4t9inE0vUHdvZ2w7scd2/SuzQNrjvxfSCU4WvIQMNV/WPO+CY6dpaBRFXFFSZDxGsWnZgJqUQWx7NiRaGto+5jIqjaOa8OnCBwXxxGMCIFEXdEiga9jEHFxJazHjpuCykgo0hCJrSTyxaN0rInmvIMq4njhXHxUBcuZyPVrS7XORDCbXwsFfI5Z362i2e088x9vlu/fVOJ+3MLfggeFljxsnOQ1phyDmeCBqWldhNmSVxVxRWlCaHSp+kFYPz1T7Y+PMBK1IRXBGCFAENchCCDlelSIrGwE10lFDVQCnMipjhsGtfniEfg+TjIS3c6TW2zqWfOcdxDlWbsZHEfCSPpk2pnFuucdt/UWsl+td2JrU9U35SSZ6qnkFHsgOxVpdxczRZlzJC3ZIDDUTBihnq4ONxwnBgITpZjhIE4qFGTXQzAEgRNFo4fWtm9Cqzysk+7hmBriefh+wn0e9RJvzA+3Atz059o0T+5G4467nSXPN6bxmq3ANk5xPBVwRWkTKuKK0oSbMD4CDIEfNj/x/CIQWelO5EZ3nHqEejTf7BtwHQfjhCIuxoDj4Pt+aNnEncwMrpvGr1bCa7peva+4tbpjK3oCkWyaJw/7eEvYTCQp5JM9BJwMtUo9j322CsYoijIOFXFFaaK5p3gQhGLuBZHFjETBxYJI6KIOXfDR/LcJi74ERsLqbSK4hOlW9SCpUHgdLw2BH0a1wwTz4U2ibgl8GlLSIhxHovrsUScw31rhLRTapIDPkwA2RTlVURFXlCYagttM1CIxCHBM5L4OW5kAQgBxfXQjBnE9DG5oiSOxa9u6usP2pEJYSkZwHBcxNXw7Vz7RfHhS1JPbmWB79F5C5FZvdUS6TSFTAVeUOYGKuKI0kU/V/ywCoBYEpGqjiYA3Exb/cCN3ugiB64Xz4iL4hO50HAc/6ifuhK238A3R3HctbkPqStjC1NhqauPmwyewoifbHuE6ggl8/CBo3Xy1bZrieCrgijJHUBFXlCY6s4l2pEFoiWcrA/E2g4tBwqA2wiIvoW2dwsWEXc4wuPZfiZztjkvg10Lr2beV2sI8bxwPv9YUhW5Ty5rnw2NX+uQiLiI4pkZgCAvPnCw2D3w2m6YoinJMVMQVpYmuXKNIBUFApx/miNdrbtXbkEKiE5cxGBx8ExbqCGKxFVxxEs06ovzwoIY4Lo7j4tcq05sPj1POprCGgyB81HDD9LaTIggit76jUeiKMsdQEVeUJhbn6wVRjAmboHRUDtUPkKjphiME4mIw4UYTYJwUEJZqdd0UxhgCQnG3ZVF9G9wWu9W90P3t+wQkhNmvTpJaVjt2PfLoAcCNHgjGpZ1NF9u2dKbrrSuKckKoiCtKE70d9drigYHAD+iqHa4fYCQq8uJG1rhgXC/sL+5ELnbHi+bBBT9yQztOWNvaNxBXvI6CxFwBjB/NoZNILZssKn0Kl3biXHHCHuZBVM3tuLGV3pwZ7nqmKMoJoSKuKE30dTY2CDFAZ/Vofd1xMEaiPHAHnBQGFxGHwIT10oMg0nMTdkGzAui4KYzvx0Ft4cYwP9x1JBGlntiXZDIX+xTHODZa3aadTRc7J++mZqSFqKIoJ4/+ZSpKE0u7Gi3xWmDo9PvrBxjAdcMOZuLGhVtwPYIobcwn7FLlOoT10QEQHNfD+DUCcRM9wyMRt3XWAzNFfvg0XelRFzXLpNXcJsN2JJuphimKorQEFXFFaWJpV6LRiAm7WHX6g/WgNtvPOZwcD+uUR6ljxggOJqynLh6OOGHRl8h17roumCB0m9tobxEIajiuizhhoZaGfRZbK31KK9yfsLjLpNXcJmM2+o4rinLSqIgrShN9HY09xQOEvD8UrwuCMWHZ1YCw+YkRJxR8rOtc8DG4UR11awEL4bx4IG49zQxiC9sRwfeDSebDI+tcpopK9ycuDsME1dwmw/YdP5bFryhK21ERV5QmFhcS7nTABIZCMBJvMxLOi4ctwR0ghXE8DImcbgktXscNhdBPXN8RIQii0jFOqsF6dkXCALeJSqVO4CZvwFrwU4j8Md3q8TXUja4o8wEVcUVpYlyeuDFkTSlaC1uPQpgrbnAwTmhZ2y7jYb+TMMhNxMERp6HdsHWpB4GJ58OB0BJ3JCzDGtAo4sbE3c8mZbJguCY8J3SrTyjkfmNnNEVR5jYq4orSRCFdF0FDOCeeMWP1A0TqAW3ihFXQRQgkTMMKxMF1woIvmABx3boom7BVKUEtsrajuXGR2PJ1jR+66JODmo5AH8tSj4cfutWDZrd6XCFO3eiKMl9QEVeUJpL9xCF0p6ei5ieGMKDNiEPgOAQSNkKBsLypEKaJiYQWu8GEAWV2HjzwEddD8PGjqm8N89/G4EQWd4OhHNTC95nMxW1MJMDTc4E3NElJvsck8+mKosxNVMQVZQKSOu4DHjVsaJoBCMCYcF4cJxUaro6DcT0IiCPB/SAU8TBPG2yhFpcAI27YqjRIuMkDH0cEcb3xAjtlmdVp5I834Sbd6nHLUnWjK8p8QkVcUSbATai4EOBEbU3CDU5U6EXwJcwVN7hgQpvcCKE1K4JvwkA2MSbsKAYgLm7ktg6a3eRxudRU3d0dhA1Pjzkf3pySdgxit3oQEMQ54fqVoCjzCf2LVZQJ8BIinglKcRtSE4Wv+WJ7iofWsbheJLo2FzsKbouqtTmOJIq+RC77iTqXmVCMXTf80/SnKvxisfnjU6WeTYLrCBLNz5vjsOIVRZkbqIgrygSk3PqfRg/D8bKJXhKEQW0GhwBDYMJe4qElGwq566Vi4RYhLPoiTlxu1fG8ugVsLegoRawefEZ4fPKYZuLyrSeQEmYMroQPAP5JNjtTFGX2URFXlAnIpuqCuMgMArbQixMKsRNVYXNAxCWILGFDqLd+YKIgNycMbnOitDJbqU0cHMfF+AHGim8QNFRbcyRMbzMTFX5JMlF1t+kS1BAk7LjGNKu5KYoyZzgl/GfVapU9e/YwNjZ27IOVWSGbzbJ69WpSqfkZKJVL10V8CQPxsm07asQJu5fhIo4HUaCaHxhS4uIDKQnASRMYwfVSiF/BJ4sbia4L1IyPb9LhH2LsNo9SzRyhVqvh+wGeN4mVHQv/CVjhiaA6x3UI/ADfGMSE8+WKosx9TgkR37NnD52dnaxdu1a/fOYAxhiOHDnCnj17WLduXbuHc0J0JHLFl5h68xNb4CUgEnEnXBZC97dEueMYouprNkI9jGQPLfEKpNJhsJxAIImgtkS+uIjgRNXbvMlEukn4j4vm/HRHqAVhiVjP1b8jRZkPnBLu9LGxMZYsWaICPkcQEZYsWTKvPSPJqm2LqbvTwTZAsYFtTlQwxaabhVHpJrbZA4LobEeknjYWVWoLRTz6M5ygIpsroYU/qZfbHH9UOtAYDBedm2ySMu1uZ4qitJVTQsRB3X9zjfn+/9Gdr08D9CXc6VbKTTK1TByMeASORC52YiF0JBGhLoKxaWNR9TbXiVqaWtd2MsLcFn4RtyGyPca60k8gKn2ywi62Scq4am6KosxJThkRbzc//OEP2bBhA2eccQYf+chHJj3uD/7gD7jhhhtmcWSNfP/73+d973tf295/vrA4l46Xe6g3PwkIhdtAWGLVCp3jRgniRJatQ2BCF7UfHeN6XtiGNKiXW3UiV7bvT5BGFvihS9314ms0cKJR6ba62yTiP2E1N0VR5iQzKuIicpWIbBeRHSLy7kmOeamIbBWRe0XkqzM5npnC933e8pa38IMf/ICtW7fyta99ja1bt4477siRI/z617/m8ssvb8MoQ5797Gfzve99j2Kx2LYxzAd6O+udzHoYjl3pQtjZLMALtdBxQ+taQje7rc0iTpg37kiYWx4EYVtSAj/sJW5MWJ3NC6u9+bbxSFKQI5F2XS+6bpOonkCBl/C8Y8+ju1M1SVEUZc4wYyIuIi7wKeCZwNnAy0Xk7KZjzgTeA1xqjDkH+IOZGs9McvPNN3PGGWewfv160uk0L3vZy/iv//qvccd985vf5KqrrorXr7vuOh772Mdy4YUX8va3v53nPOc5ALz//e/nYx/7WHzcpk2bePjhhwH4yle+wsUXX8x5553HG9/4Rnzfx/d9rrnmGjZt2sS5557LP/zDPwDwiU98grPPPpvNmzfzspe9DAjd3FdccQXf//73Z+p2nBIs6ahb4p1Sf+AxRHPiAgEOOGEbUiHABOGfU2DAdcP0Mtdxw6IucUR6EJ5nK7WJG7rZ/QnSxKKc8bjwS9IaP4Y1PSnRw8Oxmpwkm6Ro2pmizF2mHZ0eifKy5DnGmF1TnHIxsMMY81B0/r8DzweSJurrgU8ZE4b/GmMOTn/ok/Pb//yrcdues3kFv/OEtZQqPtd88eZx+1984WpesmUNR0crvOkrtzXs+/obnzDl++3du5c1a9bE66tXr+amm24ad9wvfvELXvziFwNhMN4b3/hGbrjhBtatW8fLX/7yY36u++67j69//ev84he/IJVK8eY3v5l/+7d/45xzzmHv3r3cc889AAwMDADwkY98hJ07d5LJZOJtAFu2bOHnP/85L33pS4/5nguV3o66JV4gDNAL57rDAqzGJoRLPcCtBmSi2m5iBCMejpgwQt0PSImLg09N0glXuIcT7Q88r/5UbUXaDcfhNlV8O+Go9OM4z3UE4xtNO1OUOcy0LHEReRtwAPgJ8N/R61im3Cpgd2J9T7QtyVnAWSLyCxH5tYhcxSnMvn376OvrA2Dbtm2sX78+TsGajoj/9Kc/5bbbbuOiiy7ivPPO46c//SkPPfQQ69ev56GHHuJtb3sbP/zhD+nq6gJg8+bNvPKVr+QrX/kKnld/Xlu6dCmPPvroDHzCU4e+zvEiHiMuxnETHcyEAC+s0+aE8+FGQhd7YCTMwY4E2InamAa1apTe5eBK+HgQJK3qoHG+241d9aa+f6oqbhMRW+HTd8F7rqPz44oyh5muJf4OYIMx5sgMvP+ZwBXAauAGETnXGDOQPEhE3gC8AeC000475kWnspxzaXfK/YsL6WNa3s2sWrWK3bvrzyt79uxh1arm5xXI5XLTSrvyPI/ANsuA+BxjDL/3e7/HX//1X48756677uJHP/oRn/nMZ/iP//gPvvCFL/Df//3f3HDDDXzve9/jQx/6EHfffTee5zE2NkYulzuuz7jQ6MnX3ekZqcbLhtCNHhiJeomHYW6BOLgI4IbxbeE/+AgudVe4K1HN9KAU9hUHxIT54j5Ows1l3e3hc7bjCBKE13GiPuW4x1lIZzo9yScgmT/uOmqNK8pcYrpz4rshSpadPnuBNYn11dG2JHuA7xpjqsaYncD9hKLegDHmWmPMFmPMFmvJziUuuugiHnjgAXbu3EmlUuHf//3fed7znjfuuI0bN7Jjxw4ANmzYwEMPPRTPdX/961+Pj1u7di233347ALfffjs7d+4E4KlPfSrf+MY3OHgwnHU4evQojzzyCIcPHyYIAl70ohfx//7f/+P2228nCAJ2797NlVdeyd/8zd8wODjIyEgYZX3//fezadOmGbsfpwI9iRSzDI29xIPozybsK+6GS+KA42GitqOhV92EwW2OCYvDmADHcRDHxa8l0smCWmyhx9h0s4TFHOeZJ+bTj4tj1WCfBJs/rvPjijL3mO4j+UPAz0Tkv4Gy3WiM+fspzrkFOFNE1hGK98uAVzQd8x3g5cAXRaSX0L3+0DTHNGf4/9t783DJqvLe//OutavqTE033TRjM08yN0ODBEWjURwxMSFIYhRx4kZMxCtevTeXqDE/SaLGOQ4REfVGo3EeiQIRUUYlKgiCyigINDR09xmq9lrv74+19q5ddepMfebu9Xmees6eatc+dU7Vd79zlmV84AMf4LTTTsM5xznnnMMRRxwx7rjnPve5fOQjH+EVr3gF/f39fOhDH+JZz3oWg4ODbNiwoTzuj//4j7n00ks54ogjOOmkkzjkkEMAOPzww3n729/OM5/5TLz31Go1PvjBD9Lf38/LXvay0np/xzvegXOOF7/4xTz22GOoKn/1V3/FqlWrALjiiit6WvOJNkON9kcjw5XLxRQz0JihbsgwUeBt6IAaLXSJNeL1zICAy1tkxoTkNvXtuLR3WBsGkHivYcKZOrD1jmuyIjgU5/Jo0c8gL9W74E6fqfUeMUbQ6AlI8fFEYukwXRG/Oz7q8TElqpqLyHnAdwjzGi9W1ZtF5G3ADar61bjvmSJyC+CAC+bBZb8gPOc5z+E5z3nOpMc8+clP5s1vfjObNm1i1apV/P7v/z633norqsprXvMaTjjhBCC43S+77LKe5zjzzDM588wzx20vLPcqP/jBD8Zt+93vfsfIyAhHHXXUdH6tHZb+cgCKYvGxxCzGvyUMQfEmQ0TJxZCpovhQamYs3gvWBtGzAmoynMvJbAODJ9fQMEYA1GGiuDpVTGXueJXCpe5djs2m9TFs410Zg99WikS33CuZSUKeSCwFpiXiqvpWABEZiutbJn9G+bxvAt/s2nZhZVmB18fHDsG73vUu7r77blatWsXHPvYxPvnJT9JsNjn22GN59atfPe+vf/fdd/Oud71r3l9nuSMiiECfjhFboJfx8HgEDiHDhI5qImQCqhKmmnmlbgwtlaidJowdNRkmusM9FhstZDEZomFq2WRNXKz6IKLFDcB0KFqsbqMV3vH6qb96IrGkmJaIi8iRwKeA1XH9YeAlqnrzPF7bdslJJ51ULp9//vmcf/75C/r6Vbd9YnKsCEM6Uq4XMXFXDkAJ8XCPYDTEr51XMpE4azy0Lg0DUMAROrVZbZbzu21FsI2PMW+ZOHZtYid2L2EK2rTQwgrfhvasXYgImSEluiUSS4Tp+tY+CrxeVfdV1X2B/wl8bP4uK5FYfDIjrJAo4h4obV/BI8Fy9pQCqaoxm1xBsnJiivMaLHGvqFjEu3bZWUVgC0F0Lp8wac3gQ2LcdBPMirKybemvPgHbdaKb6vQficQSYLox8UFVvaJYUdUrRWRwnq4pkVgS1Kxh0AURL76ygwUexpEWM8UllpX5cvxojKBL4YKH0HQtZLZb9RhTj0LcFmwjgHd477G1HqIbB55Ym5HHASVTxqX9xK752VBNdMOH9SVPh/h2Lc8J1d75PdZTDkFiHph2drqI/F+CSx3gxSzDLPJEYiY0aoYVrXbLVR8f6rV0q4sKmkUrnCwKvCASmrcIglNDXT1qbMgsB2xWI9eQpGZqfUCMw+NwXqn1quXW4Eq3NiN3Gm8apvgltnVU6TRY8h3diq53WmQ0dCPxfSke1V2T/C7jrPDudrhdr9dxeA+hTyKfmAXTFfFzgLcCX4zrV8VticR2S3/NMsRIZUuMUxtBTZwlDng12JhtDsEiz2jHjJ2Y0g3u47QyYzNo5ngFU3F1Wzx5PO+4r/RY5y3GIN5NHZMuysrm2AqvkllD7vzSyFgvXd2eTuWUGOaIgjnba5xpl7zqz8IDUBX6CUW+spwEPjEB04qJq+qjqvpXqnpcfPx10e88ETjnnHPYddddp2yi8p73vIdLL710ga5qPD/72c84++yzF+31lxOD9baIF1+5LtaCe7W4WDXuEbwxYG3lSImjSA2qBtRjbYaL7VattaAuuKMrVrch1I/3DDUXrVahjElPOvN7DsrKpkMZy1+s+Lj34PLQF77a6c5kISPfZuFGxsy80c2sKQTYmPiw4XpsvDaTxWE0tjOZUX34XdSF38u14iMPf1fv2vPkU3x+h2bST7eIvCf+/JqIfLX7sSBXuEw4++yz+fa3vz3pMXmec/HFF/Nnf9bd82bhOOqoo7j33nu5++7JZtckAFb01Vgh1Ta5EoefBOsaVTw2xMkh5LOJKb9TvXMxLh6tcpvhKklmVj3eV0TW++Aelx6Ja9291KcSzm2dcrYNhIz1MLo0d37K4+eEImHPtSrCbaNwZ/MWQphzOkTeVkS+1hZ5sW2Rh0qYIAp8KfJ5ReR9W+QT2zVT3aIXMfB3Au/q8UhETj31VFavXj3pMZdffjnHHXdcOYzk+uuv5+ijj2b9+vVccMEFpRV/ySWXcN5555XPe97znseVV14JwGWXXcbJJ5/McccdxxlnnFG2Un3Tm95Ujh19wxveAMDnP/95jjzySI455piOGebPf/7z+exnPztnv/v2yk79NQYqE8wcgtdYYqYGiRa4qsdr0aXN4uJ88TKzjZihbjPUu7LW3IjDVYUmipHJbOfEMhgn4sWoUDfRl/Q8JbRNxIIJeYfV7SsWd7Y4lvZ8k6z4xBRMGhNX1WIm53pVfW91n4j8NfBf83Vhs+ITzx2/7Yg/hBNfCc1h+MwZ4/ev/zM49s9h60b495d07nvZN+bksq6++mqOP/749mlf9jI+9rGPcfLJJ/OmN71pyuc//PDDvP3tb+e73/0ug4OD/MM//APvfve7ec1rXsOXvvQlbr31VkSkHDv6tre9je985zvstdde40aRXnTRRbzxjW+ck99re2VVf40hGQnfdRAy0jFgQtc2IwZHho1xZ1Fib7ewXA1qe1VqxiCqOLEYgiXekqwd2/YOEIyx5K4r+7xIUKtgjdDqPq5gG/ukz4ZQehYy1nPnyewcuvGLhjVFtoDYeQ8TLHmmSojrlY0/01j8ZOdPLAmm+yl4aY9tZ8/hdewQVEeRbtq0ic2bN3PyyWFi2nRc7Ndccw233HILp5xyCuvXr+eTn/wkd911FytXrqSvr4+Xv/zlfPGLX2RgYACAU045hbPPPpuPfexjONfu/51GkU6PNUMNhhjBFb3RFVoI3gfx9tG9jgiqiorgFDCmFFUvgkiw3otGLQ4D3seppRWrO1qWtnhuWdcWrabuNqzxu7Wn670r1r5QGBNqyLXXdW0LqsGCrLrMC6s7MTlzYcV3W/LJml9yTPopF5GzCENL9u+Kga8AHpnPC5sVk1nO9YHJ9w+umTPLu5u5GEX6jGc8g3/7t38b95zrrruO733ve3zhC1/gAx/4AJdffjkf/vCHufbaa/nGN77B8ccfz4033siaNWvSKNJpsmaoxpCM0orJbDkZ3tRwhAQ3UUJWOsG1jko0dIRcBWuDeFt8LEfzGBOnoKnDxBpz55WahWLoiTGhVWtpocfSsm5LvOpS7/ggL1BC20QYI1CpId+mrm5l3NeTLO95YDpWfPVnta5eK+GSnvrd69zJup8vprpV/yFwP7ALnTHwzcBP5+uitleqo0hXrVrFihUruPbaaznppJM6YtT77bcfH/rQh/Dec99993HdddcB8MQnPpHXvOY13HHHHRx00EFs3bqV++67jz333JPh4WGe85zncMopp3DAAQcA8Ktf/YqTTjqJk046iW9961vcc889rFmzJo0inSarB4Ml3qSGAKPUyNXgTIYXE4RaBGcMVkL71dBy1YfObCJ4tdTF46iBOqyx5EoZs7Y2WuJd40VFqFjobsIyo8Kl3p5+FsVvEazwKrMScu+7ktWSeC840xHbXkJf3derPn8y0e9+7e59MsHyDs5UMfG7gLuAkxfmcpYvZ511FldeeSUPP/ww69at461vfSsvf/nLO4559rOfzV/8xV+U6x//+Md55StfiTGGpzzlKaxcuRIIbvD999+fww8/nMMOO4zjjjsOgLVr13LJJZdw1llnMTYWJsK+/e1vZ8WKFbzgBS9gdHQUVeXd7w4TYi+44AJuv/12VJWnP/3pHHPMMUAYRfrc5/bIG0h0sGaoTp0RRrWGKIyRMUKG9xm5WmoYchGsmti1LWSsq29/uTnAiKIYnMtju1VQnyNiMCbUWavPw9dVkX0uQsvHePckWeZBxOP0M2TBE9omoyrk6nTqGHl5MxPj3sslw3xHZaZW9TjRh3HCX/7sofaTeu2natYzyf5l/j823QEoTwTeDxxGGEVqga2qutM8XtuyopeLu5t9992XNWvWcPvtt3PwwQdzxBFH8NOfBofGRRddVI4iFRE+85nP9DzH0572NK6//vpx2wtrvcoXv/jFcdvGxsa44YYbeM973jPl9e7orB5sgIwwSgOvGcM0GKMB1HBGUCyGjFyhLgYhxMURQV2OZI1Qx62Atbi8ia3VQUN/9CyrBQvVgcvzaMWHLxQjAijOOTLVWIPeG2uky2pfOlnaVSGfNNktWd/bP9vqStceQt/e0PvYqVrqTveGoLuFbnXbEvmMTdfn9gHgRcDngROAlwCHzNdFbc9cdNFF3H///Rx88MF84xvf4B3veAd5nrPvvvtyySWXzPvr33333Vx00UVlmVtiYlb1ZzhG2Kp9jAGj2scIfYhmqGY0xJJjyWILVisgGru0QSgzK75MxOC9p2YzaCnOezKxZXKa9x5qlaYvMS7unQvfHzKxqNk4Pc05FzLl7dL623YLuTXSmU3vXTv2nazvRDdzaTVP94ZgMq/AdPP45mD073SY9qddVe8QEauqDviEiPwEePP8Xdr2yaGHHsqhhx4KwJlnnsmZZ565oK9/8MEHc/DBBy/oay5XVvTVaMkoG3UnNntL0zTIaWBkAKN1LAaRWqgdVxPrv8OXTPnZF+KQlJCoJibD0ArTz0yImxsU7x1Io+P1RQjbs8kta2ME8cGat4Yl4Urvxpgw9a09wjS+U4X7PFnfiYVgtjcEPUMC4w5inPt+HpmuiA+LSB24SUT+kZDslj5xie2awUZGzgib6echBgCL1wEybVCnjvEGo2GamUdDLo+xOF8YziHm7RSs+Nhi1WIZC8vF9DJ8KMfqrgMXoeUdHjvlh82KkPsctbUF/PqYGcUscueV3MUiPZFY6rRUrzqRqLDEXOkwfSH+C0Ic/DxgK7A38MfzdVGJxFKgYWFIRnlMB3hQV/GwX8nj2s9W7ScnY8w3UKBFFsrLEFQsXgUM5AhWPU7C+FHVYFEbfFlPDmHoiUJ4XgUb68r9ND6mtlqDvoQJDWEU8S5McSO5zxOJ2TAtSzxmqQOMEKaZJRLbPdLcCsDjOsjvWE1dPQMqNOmnphnYBioWpwYXR5A6B2INXiW0ZhVH7ms0MoeKCa5kgqle1IFbNMTM6byrFjTUiyNTflBFfewgN/Wxi4p3iHqyLMNhQub6VNPYEonEhEzV7OVnTBLGV9Wj5/yKEomlwthmADYxxO/YmUHGaAED9NFPA6uWMTVkEpq9aLSpVTKQmKmugjcW41tgbEXEbSnixeSyXk1bjLGhK9xkxNpwm2W0lHbN+FLD5VTj3xZCLD+WoI1LeEskFoHqZMAyBN5j/1T5bbW5bDs8CVO9yvOA50/ySES+/e1vc+ihh3LQQQdx0UUXTXjc6173Or7//e9v02t8+ctf5pZbbinXL7zwQr773e9O+/m//e1v+ZM/+ZNteu0qb3nLW3jnO98JwBve8AYuv/zyWZ9zSTK6CYBNOsRGduIxVrBZBximjxEatCQLXdzUkGPaw0zUATYIednrG5AwT9yKIGWTl9AP3JqMSpO+tjDbLJRPT9bCNNaGmxhTHzc8ZSnQJeAFxoTBKdBOekskZorGsbzFw/vOh+t65M6Xj1bXI/daPpyGh4+PQsCLbokTPewC3oxOp9lLYgqcc7zmNa/hP//zP1m3bh0bNmzg9NNP5/DDD+84buPGjVxzzTXbXKP95S9/mec973nled/2trfN6Pl77rknX/jCF7bptSfita99La985St52tOeNqfnXRIMPwrAYwzyKDuhGDJtYbVGkxq5ZjTVBgEniK1KaL1qjIkZ6IAI3itiM1yegwFjspjMFpTbZJZWVcBia0tjTKgjL5q59CLWhosJsfdxFv1iUwj4BAlsIkJmQ5mcT1b5DkcvyxfGW7odx23ja41rARMrR3rvax+zlJmWvS8im0Xk8fgYFREnIo/P98UtF6677joOOuggDjjgAOr1Oi960Yv4yle+Mu64//iP/+BZz3pWuf69732PY489lqOOOopzzjmn7MK233778cY3vpGjjjqKE088kTvuuIMf/vCHfPWrX+WCCy5g/fr1/OpXv+Lss88uRXm//fbjzW9+M+vXr+eEE07gxz/+MaeddhoHHnggH/7whwG48847y3arr3jFK1i/fj3r169n7dq1vPWtIdXhn/7pn9iwYQNHH300f/u3f1te69///d9zyCGH8KQnPYnbbrut3L7vvvuyceNGHnjggTl+V5cAww8D8KiuYDN9bGWALdJgmAYtzWiqYUzDMIk8CrCqoBI++BrUHNTjtTpPXMJy2aFMsNGKLi3RaF2LzTpbsHZTDKGodHqb0nJfKIrhJZMIeBVr2hZMssqXL72s4W4LeCrLt9v6rVrA0mXxVh+Z6XzUrOl4ZF0Pa6R8mK5H8VpLnekmtq0oliX8Vi8AnjhfFzUb3vq1m7nlt3N7f3H4njvxt88/YsL99913H3vvvXe5vm7dOq699tpxx1199dWlO3t0dJSzzz6b733vexxyyCG85CUv4V/+5V943eteB8DKlSv52c9+xqWXXsrrXvc6vv71r3P66afzvOc9b0KX+D777MNNN93E+eefz9lnn83VV1/N6OgoRx55JOeee27Hsf/6r/8KwF133cWznvUszj77bC677DJuv/12rrvuOlSV008/ne9///sMDg7y2c9+lptuuok8zznuuOM6Rqoed9xxXH311fzxH29nBQtbg4g/xiAj9LEVx6AqY5rRgjAYRYSmhz4Ep2F6l2goN5M4utTiyVXITGi9Sj0L2u5CMxdjTOzQ1jX0JAqzic1celIMo4jNYIqa8dwr9cWOixc14DMoITNGMLStcu8UK7I0Y/w7GGUsWNuW8HTjw9C2dCeyfjtLuNPfe7rMOPKugS8Dp8395WzfVEeR3nbbbey///4cckhofPfSl760I1Z+1llnlT9/9KMfTev8p59+OgBHHXUUJ510EitWrGDt2rU0Go2OeeIFo6OjnHHGGbz//e9n33335bLLLuOyyy7j2GOP5bjjjuPWW2/l9ttv56qrruKP/uiPGBgYYKeddipfp2C7HW269UEAHmOIHMsofTSp0RJLSy3e1IPVi0UJ2egQRoQ6LGhOTkhc85holDucxnGjqjifg7FBfIkWdzHEJApzkbndU8h7tFm1Ih3xu0VhBhZ4L2y0pIR2p7cl4V3YTqlazxNZzVVrubCSC7ot417W8FTWb2H5JgGfGdPtnf7CyqohtF6deqbmIjCZxTxf7LXXXtxzzz3l+r333stee+017rjpjiKFzjvR6f5TNxqh45cxplwu1vM8H3f8ueeeywtf+EL+4A/+AAgf5De/+c28+tWv7jhuqhj+djvadOtGADbpAI4Q+w6JbEJTJZaMxb7lRspJYz5Gr1UVLxmGJk2thZaoKA5DLVrbTqEWm76UPdBL67q9HSpWekHhSu9qs2qNlO7ozC7CF+IsBbygiJX7aJW7aJmbZJlvExo9RBAs58ms6G6rub3e3p5YGkzXEq9mpJ9GGEX6gvm6qOXGhg0buP322/nNb35Ds9nks5/97DhrFTpHkR566KHceeed5fqnPvUpnvKUp5THfu5znyt/nnxyGCK3YsUKNm/ePCfX/MEPfpDNmzfzpje9qdx22mmncfHFF7NlyxYghAkefPBBTj31VL785S8zMjLC5s2b+drXvtZxru12tOlIEPHNDOEIbVWb3uAw5Ai5l3Zzldj6mzgfXAS0+OpTRY1F4oAPjwlxvRgrr7rNvYK6nO554Mb0iIsXA0MmmTO+4MyRgFcxRoIFV4QckmXek4ms6aolXY03Q/t/pWo997Kal1uceEdiujHxl833hSxnsizjAx/4AKeddhrOOc455xyOOGK8R+C5z30uH/nIR3jFK15BX18fn/jEJzjjjDPI85wNGzZ0xK0fffRRjj76aBqNRjkh7UUvehGvfOUred/73jfrLPN3vvOd1Go11q9fDwSr/Nxzz+UXv/hFedMwNDTEpz/9aY477jjOPPNMjjnmGHbddVc2bNhQnqfVanHHHXeUE9i2K4YfJVcTOrLRwmPwxuBQvBqUYtRoFExVVMAjVW94sHTE4r0Lx0bht+Jxvj25rJxo5vJxA2o6RpOWpWx+nICXx3fPGV8IqmVk8/BFX8TLq5a5Kyxz2TGsw22xpk01Br2DvE87EjKduJmIHAC8l5DMpsCPgPNV9dfze3njOeGEE/SGG27o2PaLX/yCww47bKEvZZt40pOexNe//nVWrVo14TH77bcfN9xwA7vsssvCXdg28qUvfYkf//jH/N3f/d24fcvp79KTjz6Vkftu5rCxS4CcOi3W2ia79TvWDQn77NzHyhWDrNt5kMGBflYO9FGv16nXGzT6GmR4TGOQAWkylu3EoGnicodrDLFTX43RrY8z5mCnFSvKbPatYzk1P0aj0dfhJvdeGcs9NRusUrwH1wRbn3BwyFgebhoWpOlEMYlsAQeZqCpeGRebFVi27vaJkscm+pYW2qIcluP2JNTbFSJyo6r2tJSm+2n7f8C/A3sAexJGkk49QDsxjne9613cfffdi30Zc0ae5/zP//k/F/sy5oexLZVe5CEy6DW4yR1hAplCiIsTlkN6ehBkMRZVj8Yabpc7bGbxXlHvsaJl5zaIfcU1uom7Ro8Wo0lLF7m6cS73booRpfOe4OZ9OxFvASeRiQRXby262k1M6HOqwX3swmAZvxDvwTTpLr/qTiDrTh4rrrs7aayaLFZ1eSd3947HdHtCDKjqpyrrnxaRC+bjgrZ3TjrppCmPufPOO+f/QuaIM844Y7EvYf5obu1oeeqJYq0hBB5c6uAkWMa5hzqEFqwKiMV4hzMWK+C8o2YaoHFsqMi4dqtGlBb0FMOOUjPvphw5uiAJbt63M+QXcQRqYXlbpLTQtZpBHe+wCst1PqzWqhVdviTTc3lXE8iSNZ2YCdMV8W+JyJuAzxL+F88EvikiqwFU9ZF5ur5EYvHIJ64kcBoGnqgKzoMagw9F4nhjEIIF7rWFo0YDT8triHW3gqBnRjBiO9qtWhytynCUKtYEEXd5joUye30iqglu89LBTTUm18mSmmEeJqVBe7a7lu7p8cLesTCjMa7bUhudRDox10z3s/2n8eeru7a/iPC/fMCcXVEisVTIxwonORD+0R0GlWDpteLXsvMeQWLtbPiitjHTPFPwYjDqwj5jETw+z6Fu4xxwD1jwPohPZThKlWLdexeWp+G6LhLcep1vVqiCzwEZV+K21Agu5nKt3N6dJFbdPq1zjjtjEujEwjPd7PT95/tCEoklh29V+pXHeeFqUA31ZKJhTGgQ9VAq5n1sUOIV0SJEbtHYbjVHMAZc7kBqGIRWjH2K+mA9F8NRemBEca2cWqM+rV8huNR71JjPFt+7vG050SnuHXsW+lISiW1mus1easD/AE6Nm64EPqKqrXm6rkRi8fGOrPKFLhBLyCBHKLzg6g0tH48IBeJ4VWpikBgbR5uUM8RRWj6Uh2UIYwSRzWKymonH9cKitBQmGYcy/jkSYuMd5WmzYRvaqSYSiflhuqmk/wIcD3woPo6P2xKRc845h1133XXKpifvec97uPTSS7fpNa688kp++MMflusf/vCHZ3yu3/u939um165yySWXcN555wHwgQ98gIsvvnjW51ySqCfDtVcRvBd87MpW1Ii3s9JDPNyrhppyfLslqnokzhM3+OCNVlNax7kvWq1arAnn7NXMxKgHEdwMrMWO15gtZSb6/NSCJxKJmTFdEd+gqi9V1cvj42XAhqmeJCLPEpHbROSOmBg30XF/LCIqIsu2Y8jZZ5/Nt7/97UmPyfOciy++mD/7sz/bptfoFvFzzz2Xl7zkJTM6R/X5c8E555zD+9///jk955IgNi6xotHmFpTQzAUvIOA0wyPkCioG9YqIwcV14134iSP3Wk4uy+L5XDmRKQxCKaaRVTuTdaCKkVC6NpNubEUp1qzLzToy0ReulCyRSEzMdD+JTkQOLFZi8xc3yfGIiAU+CDwbOBw4S0QO73HcCuCvgfFjv5YRp556KqtXr570mMsvv5zjjjuu7MZ100038cQnPpGjjz6aP/qjP+LRRx8F4KlPfSp//dd/zfr16znyyCO57rrruPPOO/nwhz/MP//zP7N+/Xquuuoq3vKWt/DOd76zfM7555/PCSecwGGHHcb111/PC1/4Qg4++GD+5m/+pryGoaEhAC688MJyFOlee+3Fy14WmvJ9+tOf5sQTT2T9+vW8+tWvxrnwZ/7EJz7BIYccwoknnsjVV19dnm9gYID99tuP6667bo7eySVCs93eNouOcyGKdywhc6EVeuyVrkDblY4YvDoQizqH94rNMpxTrARXeuEyD9PN4sdJTDkMZZxLPfZUt1kW26ZPX5CzyYaoTIclmomeSOzoTDet9ALgChEpOrTtB0zVivVE4I6iq5uIfJbQb/2WruP+DviH+Bqz51tvggd+NienKtn9KHj2RbM+zdVXX90xwvMlL3kJ73//+3nKU57ChRdeyFvf+tZy2Mjw8DA33XQT3//+9znnnHP4+c9/zrnnnsvQ0BBveMMbgDCPvEq9XueGG27gve99Ly94wQu48cYbWb16NQceeCDnn38+a9asKY9929vextve9jY2bdrEk5/8ZM477zx+8Ytf8LnPfY6rr76aWq3GX/7lX/KZz3yGZzzjGfzt3/4tN954IytXruT3f//3OfbYY8tznXDCCVx11VWceOKJs36Plgwjj5WLNVq0sKFOXNv56rmCi+501VDKpbFOWWJsnNgzPfdKn80Yy1vRtd6OexsTMs41NpCBdjlZB8UscmPIvccrTLf8e9blZttBIlsisT0yXUv8auAjhJyeR+LyVPMx9wLuqazfG7eViMhxwN6q+o1pXseypjqK9LHHHmPTpk3l0JOJRpGeeuqpPP744z1HiXZTHUV6xBFHsMcee9BoNDjggAM6pqwVqCovfvGLef3rX8/xxx/P9773PW688UY2bNjA+vXr+d73vsevf/1rrr32Wp761Keydu1a6vU6Z555Zsd5tstRpCOPlosNKvmbGuaGe5XY8lMg9lB3lRagYZ54FPWYxKaxv3rVtQ4h8QzvyLWtyOPi4uV4Ult2b8urBebTIDPRgzBTa7xIZEtx8ERiyTHdm/JLgccJVjPAnwGfAra5XZeIGODdwNnTOPZVwKsA9tlnn8kPngOLeb7Y1lGkvdZ7MdNRpG95y1tYt25d6UpXVV760pfyjne8o+O4L3/5y5O+7nY5inTrw+ViP00KSfeEBDeNLVghxLWdV4Rq3DlsV7GIjqJSi+ntDuchq2eM5h7VkK0OoQa9Fl+nGhc3yDhLuGgxOhOMEcQH8bfTtagXqaVqIpGYHtP9VB6pqq9Q1Svi45XAVIO77wP2rqyvi9sKVgBHAleKyJ2E4Spf7ZXcpqofVdUTVPWEwpJdjlRHka5cuZKdd96Zq666Cph4FOkPfvADVq5cycqVK+d0FOnXvvY1vvvd7/K+972v3Pb0pz+dL3zhCzz44IMAPPLII9x1112cdNJJ/Nd//RcbN26k1Wrx+c9/vuNc2+Uo0i0PlosD0r7xUqIlXhFx1XbvdJVC5BWnUlrfhQCKOpyGGyuI9eT4MEu8knE+Li5eJJRV3O3bYlVnxkz/eSkOnkgseaYr4j8WkScWKyJyEnDDJMcDXA8cLCL7i0id0N3tq8VOVX1MVXdR1f1UdT/gGuB0VZ3qvEuSs846i5NPPpnbbruNdevW8fGPf3zcMc9+9rM7XOaf/OQnueCCCzj66KO56aabuPDCC8t9fX19HHvssZx77rnluZ7//OfzpS99qUxsmw3vfve7ue+++8oktgsvvJDDDz+ct7/97Tzzmc/k6KOP5hnPeAb3338/e+yxB295y1s4+eSTOeWUU8ZNJrv66qt5xjOeMavrWXIMP1QurmAkLsWOaTHe7TRYtbkqKhJENnZsE+9CGVjs1GZNFtzoeBy2TDTLvYJ3WGPJu3TVmmhtlzcCtmMfzFzEbTFIZTrPS3HwRGLJM113+vHAD0WkGL+1D3CbiPwMUFU9uvsJqpqLyHnAdwALXKyqN4vI24AbVPWr3c9ZzhQzvydj3333Zc2aNdx+++0cfPDBrF+/nmuuuabnsS9+8YvLJLeCQw45hJ/+9Kfl+pOf/ORy+corryyXn/rUp/LUpz61574tW7YAcMUVV/R83TPPPHNczBvgZS97Wel2r/KTn/yEI444oiNpbrugYomvlOGOvpxlZnpsyqIqGKWceOaNxatHqKHehcYv1uKdJzPQ0sLSFrz3IB6bZTQ9HfO/rRHyXPF5Hs48brIZM3apQ7DGW85PPms8NXRJJJYF0xXxZ23LyVX1m8A3u7ZdOMGxT92W11huXHTRRdx///0cfPDBi30pc8LDDz/cc5b4smdr2xJfzRZKKxxCQhtB18tJZnGDahDn3CmmbhB1gEFFcK0WDSOMaRhHaq2QuxwysNZCHENZL0S8iIv7HGPHJ5VZEVpxpOVM5mcXrVirr9VBmURnkoAnEkuc6fZOv2u+L2RH4dBDD+XQQw+d9Jiq5bzU2e7c6AWV7PTV5nGKHqtF6xcITV28CUluOeBQrKFsDYMYvG9hs1oUeBc0UUwo9TLC6JiDTLBZhuStDjd3SETzOPXUauN7pZfDTXQmTVjjc2Mr1p43AMVgk+RGTySWPCndNJHoxeimcnGtdCYTqoa2p06LUjLiABNDyykSa8lFDKKKEqx1imllhJi0ie1Yi9KyzMi4TmxWfBD2HoIqEoepbEMDl8yaWKbWoxYdkoAnEsuE7UbEZ9VOMjHnLPu/x+jj5eJa0xbxwo2uGpLYnA9Z6s4DEkZ++miFUzR9MdFOVo8ai4lWcCZhWxFLNzK+NaoVRY3t2Uc97A9Z6hPtnwwby9TK56a+6InEsmO7EPG+vj42bty4/IVjO0FV2bhxI319fYt9KdtOc2u5uKu0u7dJLCXzhP7oDk9LibXiPpSgeUXFxMz00CTFO4cRJVfBWsG52AddwFUscahY1t4HoRcz4fCSMkt9WxLcqtZ4RznZdvG1kEjsEGxTB8alxrp167j33nt56KGHpj44sSD09fWxbt26xb6MbScfKRfXmC1xKdR/exWcC5nh6gVUEBOS2TAGVQfUMHicgpXQG71hQo153QgjuYM447uYSFadNpZZQN2U88WrLvXaNnjAy0z13AXtTm70RGJZsV2IeK1WY//991/sy0hsT+Rj5eIusqVcLmeIS2yziuIFwJZjUlQVFYtzDhvLwtQ71Ao5Qn8h1nkLazPGopVdnTYWXsyBsRjfo496hW3NUoeijM3TUk/D1pIbPZFYZiS/WSLRC9ful76T7WyVW3RmQ2O3Ng3DUJBgqVPWkDu0sGzVIcbGRDgJPdSdx9pwH12ItI1DSsoEMwmNYZSJE9hmNS9clUxCj/eZzChPJBJLgyTiiUQvfLvXfMNoe9RonGSWR3d6jiCqeO8Ria1YhSjmiohFfai71vhxUxTRkHWe2SDyxTCTsp2qCxPLMKYi0r0HnhQu9W1p/BK6xQnGZjMeqJJIJBafJOKJRC+0U9CKmeIegpab2H7VKy0frWSv0dI2IclNQY0hON1DyRmEY60ouYLJbDk4BdrJbXmelx3aRCRY6JNY2jPqiV5Q6cpWTDjLXRLyRGI5kUQ8kehJRQxtRk2CezsMJSGWdUnMRg9Gc9HNTcUghXAbC95jBJzY2C1NQ/13zEq3VkpXuDGCiVY60tkrPSSRT+xSn9F40q6ubMZIeW2pyiORWD4kEU8kuqkktQHgoU+Ce72QNx+tbweIUQRo+dCVrVX0YRUbO7XleAy5xmz03JEJqIT678wIviKeGT7E2CulXtk04t5GJJR6T0eE/fjpZFm8EWi5JOKJxHIhiXgi0c1YtUObgBEGTEh0UwREcIAvM9QNOcRyM1AM3juUODEsz0NsXMMHLncOU6n/7khM0+BqV8z4FqxM7i4fV2c+EaUbvbOcTETIjMGrblMXuEQisfAkEU8kuhl+pLJiQAwrbLPcUhqqKqiPdeM5qAlNVxRTafIS3NtqiqQ2yvpvYpy7Q3zVh3Vjx7nGO8rPemBKl/okAlx2Zes93MQaiR3lfHKrJxLLgCTiiUQ3ww9XVgTEsqoi4qJBC0M2eJgI5mLuedgWHmJMmFIGFD3TITzZEeLjrZjVbmI8Gu8w1mB6CPZUpWblMZO1YdXxbvRuajYmuSVrPJFY8iQRTyS62fxA57oIO1dEvJBpR7TKQxp6iGMjsZwMvFhUQytWjVYyGuLnDkNmDc61s9Kda/cuz8z4VqtTlZp1HtNDgIsbiim6sgW3eriJSG71RGJpk0Q8keimKuLGgLGsqY3SniluwkxxjQNEUFQ0tGKNmemIDQLvg+u68EzneR6ywDUIZRF/tkZQl5cTy8p68YqIVsV1IiasGfdxdMs0h5tk1mBEaLnkVk8kljJJxBOJbqoirqHBy9p6JWO9mBeioTe6dyHhzalHMLRaIRtdiqEi0v6Y5XmOtTb0R69Y1pkJU89yDbHybAKruyg1m0zIa7FmvKz53sbhJjUbriFlqycSS5ck4olEN1sfbC8bAZuxa60t4ipFEluMHePJncbZ4bFCXASNDWOMsTgf54x7jzEWr6EkTCQMTrECgi9bnxojoba8R1wcJnepj0tw28YZ4SJCzYYkvdQEJpFYmiQRTyS62VpJbBMDCLvWKjHxaH17FcIYcRObvBAmmXnIvUE7xFPxvqg1jxau92WDlaL9aa5tV3evuPh0ureF58YEtzxnJm70bmylCUyKjycSS48k4olEN9USMxUQw+59Xe50icltPg4s0TD4pIiPqxG8D/3P85jFLoWox37pRXlZKC1zZDZY6EVmeWZ7t0LNrHQc1wtrwuTz3EV3/ixmhNdSfDyRWLIkEU8kuhl7vL0c3em71NoDUTS0TA9Jaao4JDR+8WEYinoTJpX5mOAW27I678NscB8s5ZbTINTOkeeOLAsTzQrre6IubdPp3iZStG8NbWBnS80GF30zCXkisaRIIp5IdDO2pbISpp2sqoq4th/QrhkPrnCPNwbVMPms5cMT1PsQIxcT3OhWyF1MaMOHRLdaDUHKeHeRjT6RS33SPuneUbPEpjGzF10RoW5DwlwS8kRi6ZBEPJHoJh9pL4sBk1HPLLYcRxprxTV0aAOl5cIsce89qqFW3BP6oyMhoQ2AmOSWxbGlAoh35PGjWB2GAu0ubd2u8yJLvadLPQ43EWOx1pC7uRlqUhXylLGeSCwNkognEt24SvxbCIlpYqmbIFzRuMYj4IvpYsHKdqqoGFzZWCVkdwsujjGNteZRA1t5Hpq+aPgoFsNQCnGu2bC925ouy796WeM+p+jKNh3X+0wwpp2x3syTRZ5ILDZJxBOJblzbdY5k0Rq39NkgWLHxGs772LVNEUIfdedDmZlzDo8Jc0YEQsNUS2HJi2h8qSDiuYbpY92iaycoNZuw8UtXOZkxofnLXGaWWxMscq9Ka46s/EQisW0kEU8kulHXXhaJIi4M1TyFHMeoNV7DXHCnSq6KR/AioIpTg6KI9+S5b1vlArmHTIIlXosJbSHRLSTFVUU3M6anxT2u8Us53KSznKxo/tKaw1pvUxHyFCNPJBaPJOKJRDdaETuxYDIwNVbV40Sy4jAIk8xiFnie5xgx5K1Qm+3Ldqs+ircty8pazpOJhoS2Mis9nN9a6RDtCUvN4njSlvOTdmWrWuNzKbaFkAOM5T7VkSeWFKo6q0cR1up+uB6P3Plxj4UiW7BXSiSWA71izDEmvqYRVkN9eBDFlg9NX1SCBe3FoKEFTBg3CrRaLsSRCQ71oid6ljlGEZyGXuWtyjCU0ZbHe8UY6XCxZ5WmayLSHk86RVe2mjGM5SELvoinzwXGCHUJ195yHq9SxvG3e+bT+zCNxjzdN2Tdl9N9dRPdwE31W8z019QpzziNcyzz+0GRhRPXJOKJRJVmV3mZrQVLXITd+n11T0wtD5PMvFc8npYTxHu8hlx25xSLQ2oNiq/lYJx71IdOaoWwjjQdqkrNGkZbjpb3NIyN7U+D9d5X6xTpmjXkeYuWU2pZbcIv/8Iaz52SGS1vMOYCEaGehZK53CteHTUTxqkuO6rq0aEkc6sqhaAWL6GV7R2v2rW/47Kqf8NZ/j0ne7ows3MLMtvLmfXzwzlm+Z5Meu65fa3ZkEQ8kaiydWPXBoku9Rp7Dra/Sj3gHKjXkNCmoCo4onudOoKJA1BiwxWpWClxMIpYS8t5GpkFXBR0U/ZUb8RPaGYMLefKiWcFVsDgyL2lNkVXtro1jHpPyyn1bO6/dMLkM6XlPU3nsXFS22J+wfWkVMbpinS8WytXe/8+bSEuShC13B62VYW7co6O6ygSH6tr8QqKbdIO6LTfW62csXKOyrXKLLr2JZYuScQTiSpbqrPEJcbDBWydPfuLdLaCENMWCZZ4y4chKF7DV2rufShLE0FFUFWMhGQwg6elQXhzpww1osvcKTUbSshaefvLvWaFkVaIf9uqy9w7MmNpYkr3+0RU3e9THbutGCM0jC2t8uKmY9HEvNqVZ0KhjiI9hWUbYqXFKbVDnCdz/4oE69RIl0BL28atbpsR43zo3TcmlXVfSdikfMHOn4llRxLxRKLK47+trMSe47YOCHsOha3Fl7fXYJHnYXA4XgVRT+4AMeTe43MHjVrssKYYo+QtR78RWl7orwnDzXBzkBlD03n6sWGZPHR1i5Z5kRBXutS9A5RaLaPZCtZv3xSTympWyozyqY6dDZk1WKOlkBdibkXmz83eYWH3UtWKYE0m0hA67DG5SFfFuVuYw0ssgDCO9+uOP2ayEEEvf30S+GVFEvFEokq3iBNqxDHCHivq5Z6izMxrW6gwwfpWTOzSpnhRBNPuzlb0VLfB9W6L5Den1LJqXHx8MlvNGkZa0aUuxHIygxhDZrTMPp9MPIrxos3clzcI80URyy+uzWn4KT6MYQ2PWYjdpFa2jBOhDkt6G0R6wQV6rpgqdj5ReGGcwCdxX4okEU8kqmyuiLgIZFlwqduMNX2dzV7CzPBgkede8U7InUNsLZSUxVI1tYbceeo1i3ofJo6bRlGjBgQ3ecjqdjFmbbBGgsUcLe9Ol3rIgC+y0evWMOzdtOLdtkhy84qd4yS3XogImRUyQla+j2Lu4u8uEmerM4VQTiDa5eZK2CJsLyxrv32L9GyZTJTHCXyy3pcaScQTiSqPV2LiEi1xMSA1VtSDYCpBuJ3TkMwWY6Qh1uzxsVmLmNCCNfeh9lvjIBRDiJkL0IqZ6S3nGaiHTPSW89QzU2apF/HrMku92aKvz3aUkxnTHopSn0b7h7o1jEYXfCObP7d6N9YIFqFmY0Z/jC17Lazh8TFe6eEaL0S7Qyy63OhJpOeAiUS5l7h3bC9P0H5+es/nhSTiiUSV4Yfay0IsL6uDsRhR6gZacbRoqBcPQuSJc8XF4FWiKHmQWkx0C+1YUQfWkmtwj7ec0sgMw82QdJRFQQdKEa/Gr2sCLfXkPiPrqveuWWE012m5ydtla1rxAiwsxgimq5BHvS/7xof3r9AD6RCC6rOksi0J9AKxLeKe3PLzwrx+ckXkWSJym4jcISJv6rH/9SJyi4j8VES+JyL7zuf1JBJTMvJoZSV2a7NFgluN/pqUsVRUCalloeWqxNhqrgreh+YnmCjgYDV2NYud24wQx5GGL7Gm89SMKbPHg9u7LeqokolHjKGl47/4QolXOM90yKwpa8d7TkNbKOL7hXcIijXBYs+yjCzLqNVq1GoZtcxSs8FDkVUe1kj5XiUBX2SKGy0TPzMmeowkerSq3RI0tgn2Lj58bB1cDZskpmLeRFxELPBB4NnA4cBZInJ412E/AU5Q1aOBLwD/OF/Xk0hMi9HH2stGKEaRIqH16lA9JklRTDNTvAfnBecduUrofa4uTDOLBwqK+tgWVdofu+pXVSgvaws6BLd32S7VO0QM9Vptwn7lYcLY+BatE1G3BpFFmBFeEe7Q5lYp3xtjgwAkF+z2QxL3eWM+LfETgTtU9deq2gQ+C7ygeoCqXqGqw3H1GmDdPF5PIjE1reH2smShvMzWCUNFlJ37KgJc9FiO66G3cshKz1txihmAhOy3Vu5QscGxLpQKnnulbk3op27bCW3QHkXajP3YMba9rYdQ12ZojVdnhI/l89zvebrCndhxSOI+a+ZTxPcC7qms3xu3TcTLgW/N4/UkElOTj7aXjQFrARvar4pl96F2GknxHeK9jyNIQY3QyvOQjCUSHOkKuY+52MaWs8RzDcNQmrmnloX4tI8d2/I44tMawaBBxON0ssJ9XPRa76awxqc7tcwYoZ4FIW/Oh5AX4p2EOzFdkrhPmyXRh09EXgycAPzTBPtfJSI3iMgNDz30UK9DEom5wbXayya60m0xycyw14p2hroKeAmudO9daPJCcGWrSKgXj5nq6nPU2PI7RaQoKwsx71olLh4ENTRkQZV6rLP2lXSuws3ey21eWOMzGT1qTSgDc17nRsjHWd0k4U7MniTu45hPEb8P2Luyvi5u60BE/gD4P8DpqjrW60Sq+lFVPUFVT1i7du28XGwiAXS2pizi4dEKRzL2WVkrd4fvB8ULoEIOjDmP+DBj3GvItPbOgQoitj11TNvfJUV8vXCDF73TWy7EwevWgM06XOQ1K2Usuxf1aI3PRJBDwtgshLyXuzwJd2IhmEzcy973sQRxOxP3+RTx64GDRWR/EakDLwK+Wj1ARI4FPkIQ8Afn8VoSielRnSVuaiBxihkhq3yfVUHEK18JqCc0LlHBO0UFmj58ceRe8d4FkY4C3qFlcbmZBwu8EM+aFZrNFqCYrNYRJ4d2LLs1QWZ5Zk3ZpnUmCWvbJOSTucuTcCcWkymt9hmI+xIV+XkTcVXNgfOA7wC/AP5dVW8WkbeJyOnxsH8ChoDPi8hNIvLVCU6XSCwQlQ+pKdzoFmp1QFm3qtFxlIuJbc55nAioJ/fB1e7Ugzq8arwRILRl1aJbWrC2i3rxWkwwazlPw4RpaE0XLIx6FgacVN3njSx8fCdKSKtbg06yfyKqQj7acr1vApK7PLFcmZZLvodbfpzIT/FYIOa12YuqfhP4Zte2CyvLfzCfr59IzIhqPLxoaWozMPVglRvLHtXENkLnNe8cTjNy52nlOU4zasZG4zTUdSvCWO5L4YXwPdLMPSv6MoabjloU+rGWY6gGIoYxr9SJHdYIHdaKRi4iQiMz4bx+/PxuY4K13nQz75Nei2NFm7lnLA8ufmukYo0Uwt7ZhCWRWLZM1XxmMit8ES301LEtkSjY+nBlRaJw10KzF69gaqxsZO30Mg2Z6V5jtzbvQQ0+tk4tys0wNZyCJbQXLZ+u5SsBoQVr3QrNZhNqDer1Gs3cl0NNalkYT6q1dr/zug0iPtFUsnoWEuDGco+dYTMUa8JNQtN5ms0ca4pYfNGKNgl3YvkwH30Q2qcc/1lYqKzxJOKJRMFj91ZWJLjAs3qsF89ABLGW/pphpOVjqZig6vBapxUnY0GIX4uGcaNe2hasiAnir1q2CXUaBoCMtTwNo2xWpaVCIxPGYtvVRmZpZJZm3mIsbw9FMaZtjdfteGscgtt9uOUYbXn66zPok66KQemz0AJyF7wP1lJm0+8ItAeqVLb12j/ueT3ONVEf+GXGcrzmhUSEeR31WyWJeCJR8Miv28sSXenWRmu8yFC3rOq3jLRiX29VnIbObM45ch/ni3sld45aFsS9TvhAW4GW9zSMjeJsGGs5GjXL2FiToYEMsDSdMtiwQdzzIOJFfXhVxIHSZT6W9xbpqtCP5W7qgSeqnQl+YqjVLNYqLe/JneK8C2Vpy6jVace8cG3LaTGOtFimsn02TPdtmenbJz2svgWn6xKWyb8A0MtmnuX5FvmXTyKeSBRURRxT6diWAVmZ9LLbihq/fbwV8lwgtl4NE81y4rQy8eTeINaCD93chCDw1kochxI+/LlXBtSj6skx1GtBcAcb0FezDDfzMEPcCH01y9axvMxmh3bseyz31Jz0jH3XYl15yylGegw8mUas2xihYSzet8U8dyHbPjNxPvgCW+i9hLnXjPDJBLnXuG1B2m9Bx7G9BrB07kskFpIk4olEwaN3tpeNabdctbXYR90SMtT7+Ml9w6VgeA3NXpzPQmwcyFs51PpD+Veccd3yijGKVRPS14vvfF/EvQ1jHho1w+bRPGSpZ4bhJozljoF6FhLOjDCau1LEIbjMW84zmnuGJkhg66tZRpqOsdxjYue3bUlUK8RcVcm9ljcHxHay054PXqEar5zMWh43JKsH3aIsSAjhz+B6EonlQhLxRKKgGhMXA1mt7Uo3GUgoFTtwTR8Qm7Sox6vHYVEjwUrNc3wtC93cXBEvlXJ2NlJEziVOMVOaTmjU64y2HEN1iwiMthwr+mrUM8NYy9MfE9oamWGk6Tqs8bDdMtJyk7rM+2qGkZZjtJnTl0UhL37fGYpaMc60ZmnPU4/x/rysXZ9YbYtUgem9Vvtnt5WchDmxI5NEPJEo2FrpN2SytoATs7FtaPRy0C794RCCOBftT70P663cIyI0c2WgTmVet6AantdyHoPg1FOvG8a80G+F0Ryaccb4WO4ZUh2X0NbILGO5H2eN1zND7mNJmOmR5KaKqNJvYcR7RltCo2bJpoqRTwMRGTffXDWI+mSJX5WBbqVjoirKxXoikehNEvFEomBkU3u5SGir1IgjGYjlgNXBEveEyrPg+hVy73G5R/sMTW8YMLGkTKMVrkVrVSWzsYZcQIwFryFjXWCs5RloWEZbvhTuzBhGW65MaOvLQqy82+ruyyxbmjnDLcdQI368u1zmIob+RrDaR51Sx3fcDMwVIkLQ9QUU4dZoHGJT6bAlAgOrw/6RRyEfC9dk402arUPWWLhrTCTmkCTiiURBszKG1GSQ9YWktqwWYuSxF/jeq4MlHhq0haQ2H63OMNEsuMlRoovZoxp8x6EzGyEObgVja7Q8ZFYYjYI92nTs1J+RGWGkGYS7r27YMtoW7XpmGMuF0ZaPM8GDUBoj9Ncsw03H6FiLvlohztLhMhegv2bLGnOvwfpfMKtXFZpbYXhjeOyxPrzHd/0I7r0exjZDc0v42RqGP7k4PO+Kd8DNXwxCnI+BGwPbgDfcFvZ/+Vy4+UudrzW0e3v/F18Ft1/WuX/1gfBXPw7Ll/4h3HNd/Lv3QW0A9lwPZ1wS9l/2f2HL78L2+iA0VsAuh8CRLwz7H/h5uCnoXwV9q0KJYiIxjyQRTyQKXGX+jmSQZdFCi41fosCt6G9Qt6FlqprYuU0F5xxOLRq7No62QoZ52B/qwa0qEru4OTXY2BhmoB4s78F6xgiOkZajv27ZPBoy0RuZZcQ4Rpu+tLz7a5YtYzkjrZD0BuGFagINo2UCW73Wu4e5SMh2b0Yhd83gnh+XuT4TRh8PCYKbH4DN9wfB2/wAPP3/Qv/OcN3H4Kp3wfAjne/3/7oz7P/lt+Dq94Zt9RXQGApC6VrBah7aFXY9PAhsVg8CXh9sn+eYs2DdBtpBcxMEt2DDK+GQZxHusHJwTejbqb3/sOfBbkeE18tHwo3dysoE5Ud+DQ/8LNxYNLeGnwc+rS3i/3YWPHZ3+/jaIBz5R/CCD4b17/yfcO1Du8HQWhjcFVbvDzvtue3veWKHJol4IlHg8/ayrYHti3HxRrRi22K4eqDG7zY3QytlHxPcPLTiw4Uy8hgrDxZ4PVPUO9QIYgwYKePFhcS6OGN8uOlYM1hnq8BIK4hrf92yZTQv3eqZNTE+7qgbR9Uj3lfL8OIZcYpYpWYntrDrWRiWMhZbrOYuHN+zTevm38HdP4RNd8Ome4JQb74/iNSuh8HPvwBfP7/zOf07w8mvCT9X7QMHPR0G1oRH/+rwMwveDU59I5x6QRA/0+P1N7w8PCbikNOA0ybZ/8yem8vs+BNePi7ZToFyCPyffrrzOS6PHoFYV//898HWjejIoyE8M7IJdj007FeFn381vF/VOvzjz4bnvjP02/7IU2DFbrDTunDzsNNesNcJ4RwzZHtqyNKrSc5SZ8p+DHNEEvFEoqTyRZE1glvUxFrxSmIbwF6rGkHECXFv5zQMQ1HIc49zYfp3szJFzPuo7FKj6aBhwg1AloU4ec0ahsdyVvTVeHy0RdOF5i1bxxx57No2ajwjTRdc30CfhWbLs3XMs1NfLdwcxBuN/prg1THcdAzUmdTCNkbor1tamx+mdceVjG66B/PYPWSP30P22F2YZ/9/cNAfwP03wefPDk/qWxlEZsXu7YEPBz4N/vRTsGKPIEZDu3XGmw85LQrtBDSGpv4rTVAbHv6COl6EJ2rmMuUrTQcDth+KITN7P7n3YcX+834S3qvhR2H4IdjyIAyuDftHN8PqQ+Dx38LvrmwnWj7ljbD6YHj8fvj4H4QboVX7wc77huV9TwnLiTlnW4NLC5mLmUQ8kYCuqUPRfV6rh3h4kQQF5TSyg3cd4sZ7Noc4OIpDy0S3UBuujDnHoGQ0c6XPOlCD04yWh7qpiIsaWt6zolFjazNHYr31SNOxU1+N4aZja9Oxst8w0LA8PtxkZKzFQCxFG6xnbGk6hnNlsNH+9hARBuuWrc0g5P01qIuHB2+Gjb+CR34FG38NG++ADa+AY86ktvUBal95ObkaWv1raa7ch+aawzEMYFoOu9dJmFf9ALPz3kj/qvHv4877hccUFEIMkzdqqa5PV3Q7Mtvj17Bpb4jvTfX46nvWcdj4c0/y7Tz9720Ljd1g5906N9d2hhd9on0+NxYEvT4IdRseRzwnhCseuB5u+2LwHv3hh2G3A+C+H8MXXx3c8zvvD2sOhF0Ogr2ODzdcC0CqJFh4kognEhDcxCUSM5b7Y+w1a2+P4zYP220FcH+YRhy6rOJ8u0Z6pOlZ0Rd6qNezkOCmWLwIsf8LEG4AvFfECM6HGPZwyzNQz9g6luNUGYjWeKuVU7NC3YaEt3oWysMyA30Ioy0XXO2ZCRbeQ7ciD93K4IO3MrzbCYwc9af41mP0feTU9q+6Ys/wZV9Yy7scAv/jR2Sr9iZrrAhNalxI3HNeybMhWHNYeDfG8nYzlUm+u7ut5OmIcVn3TegE164Ll3H14RTHbm8CYvpgzQHt9ZV7wvP/ub3ucnj83pBAJ/FGc7cnBJG/+0fQ3ByOe+nXYP9T4TdXwY8/Gf7Guxwcfq4+EGp9C/lbJeaYJOKJBMBDv2gvSy18sWV9IQ5ezhWPGeoIR+65AgiN1zS600NPcS2PaeUel+Woy3BqaXqwXkN70pjQVs8sXoNrfST3DNZDZvlQ3TIMbB1tsbIvY0SDy3zVQIPBRo1c82CdDwex7gPcuicz2swx79tAffNd7V+nbyWDA6sZzQxjrCR/4Wfo32Uf7C4HdiaFQUgW2+3w9nNFqGdtcezIxK8MBvETBGALmR3fpGW8GG+XQjyf2KzT67HH0XBmjNmrwtaH4OFfwu5Hh21bfgd3Xws/+3zlJAJ/9ZNgvd9zPTz6m5A4uMshKbN+mZBEPJGAEOstEBPLy2L2s4l904sSLREO3a2d8eyV0J1Ng5DnXnHqaeYt1NdxAGLLjm3ee0aaoQ2qULiRpRw5KgLDzZyBmrB1LCevGwYzz2aXMeqUvh/8IwN3fJ8tD93F1rGHGZQxWHciAy+/jC2qDB9zNgwOUt/tUFj7hBCXFqGPMF505JDT2KJQx9DwOqN+58YIZikM4EhMjkjI5B/atb3tqD8Jj+ZwCKE8/MvwWLl32P/f/wY3fDwsmwzWHBQy9V/4sXAjO/pYqBjolXCYWDSSiCcSAA/c3F42WbTEG8HaMTEuLtEiVxjqqzFYDw1TVBX1Sq5K7h25V9R7wDLqlP7YCKauFo+Se8hEURTnBWug5UJW+shoi/7RBxi+92Z2eexmhu+/nc0P/4LVbGbs1T9my1hObdM9NDIhP+K5jK5+AtkeB9HY/TBEhKFGxpYnvZZhr/ia7Zh2BiG5rZqJ3nQ+tk41S3oiWXcMvdjWuV7s167nTuf8s7i2ZZY5rVqH1YeHxyFADuQ5PO3vYf3L4cFfwEO3woO3wqaHoaXhoC+cB3ddHaz0XZ8Aux0Jux8Dex27yL/R/LGtf1kBBhsLI69JxBMJCJZJga1HSzwKubExwc1T+oMR9lrVx+0Pbg014F7xzuF8jVbuy4f0C604JCT3inMetQZrDNpqkj/6K8wjt6Ebb8c89Q20sJhr/wX5yRcYpsmKnffi8bXHMLLnoQzVDY+Oerac9l5WDtQYBPKRFlucR/pq1KEU8uFmiI87rzEBrjPhra9myxGmTedpOVdOI7NGsHFAylyI+kwmjVXj5t2Z53NJr19rtr/pUr0Bmi5ia7D20PDoxZEvDGVvD90Kt30Lbvp/oSb/JV8J+6/8h1BdsPuRsNtR7S55y5iJExwX9DImJYl4IgGw5YH2claHWj/U+0N83FhCxnqljanAYXus4JcPbo1Z6YpTIXcOrxangoqQOzAKY80xGrYOtQZ61zXkN30SHrmDBqMIOdgGzeNeTG3NPgwf9VL6j3ghwysPpn/1ztTGHJu9ZxdjGGpkbB7N2TKWM9TI2Kkv4/GRuE5GPXZdG2xkZaLb46NKf82Oa61qjNBngrWeO0/ulZbzcSJZoHMiWWcmd0G1fKsQ37B9ZgNOqvFxI6E97LjBJ4zPIO+4Qamcr/P8S+hbd7my/o/CA8If9vH7gou9kYX1X34JNt7ePn6nvULVw5NfH9YfuzdsS3+LOSWJeCIB4cuooNYfmo0U7vRiAEqcJ14o2ob91vCV/36gnZ3ufIiL557m1kcY27wRP/ZbxrbeTWPLr2k96S/J1x1FS2qYxkrsMX+K7HYorV0PpbF6b1QsVoSx1Qdg+jJsy/PYSIud+2s8OhyXB+sx+92RxfniK/qCsG8ebTHYyNr91Ws2NI5pudhnPUw6q9nxFnZmDZkNzylGjBb93ts/QatNSip0i2/YRvlzh8oq3xEQgZXrwqNYf+0NoRPfAz+F+38afhbW+NaN8M9HhEz6PY6GPY8Nj31P6YzbJ2ZMEvFEAkL7zYKsEVp1mkZs7VkPyTwK4MqhKE88cE35FJ+38NaT+4x8bCv+N1eCbGGs5unbaRXN/Z5Gf99KnHrc7kfD3sdj6oYxJGSoYzCioRd6Ztg85ljZl/H4aM5I7ssGMIUF7ryyeTR0mOurWXbqz9g8lrN1LMwhH2pkcbKYYSdrGMvDHPHhZo4g1DIhM6anoBcjRucTrdwYoDpp05ZJG7lMcO6pjpkN21MntDlFAVbA7qeER8FwC5rAM/459Ci4/2fww0vA/ys8+x/h6DNh013w08+FTPrdj4ptaJfxzZ3Ayv7a1MfNAUnEEwnobIPZGAqPWiPU3goEazwmt6mDb13AAffdRMZf4VVQHcO1LLkfILcDtPY6idbOO6Or1pD3WXx/nVajRp8YVA0OZSwPQ0dCYpunISa+VlCJ0Tz0VN8ymrN6sE5fzbJ1LMcIpRt982iO88pgI2OnvhojzWB1b3It+uu2HGrSyMII05bzNHNPK1eahJsAESEzoexNukrAxr1NXcljEwltT7d6pXPaTKmWp43f17XefVPS45hZ0esalrHeLAjZStjwkvZ63gxlnTutg0yQR26Da94fPlsAg7vAHsfAM/4OVh8QmjGZhWljOhekjm2JxELiqy5igWwwuNQ3/y64BB++PSTz7HIIvOADQdjvuByzYg/26W9y50g/agbwNRvqxb3SGtiNvFYPg0XIyD3kPljaIkLNG6woRsKgkro1eAUrMNZSBuOo0J36MjIrbBpusXqwhmrbAt+pP2PLWM5w05E7Zagvo78e3OVbm46tYzkjTaFRM9StIbNhuEnRfrWIgzuvZXncbDKtO+vA4zYRDJRzw4XOOHfxvKqrPf4VSld7t2XdzWS7k9E8MVO9r/OK7YN1laz2w54Nb/oVPHgL/PamUPL525ugf0X4UFzzIbjuo2Gi3B7r2z8Hd1mEi19aJBFPJB6pZKZTDy0qf/QvsOXesEkasMdRocuVrQXVeM21IIYNX7qZX99wb4iJx5arTa+0PIzliiLkuUIDcu9RNSGb3XlyMYzmPohqFqxxMBgTh55Yw+OjOTv319jSdDw63GL1QHDRbR7Nyb2yopGRGc/WZs6jw00G6pb+mmVlf41m7hnNHSNNxwgOa4J7vchANyKVUaUBjY1cimVoC6GU2yRsiwl+hWRP1i7V+9J2r442H2/Rd11LYkcig9VHh8eRFat9pAUrD4O9nxYmyN12FaCh9PN1PwufyTuvDt603Y8KY2AXGRFh9eDCNMtJIp7YMfn1f8Evvx3u9u++tr0964P+lXDYc8N0rXUbQivL+lDobuZddL0Hk/NZR+zK5264F5UgVC3v8c6T+2DljrRy+uuWsVaox245pR7LzaxvZ36Ptjx9mcGrYghC732oHd80mrOyP2PLqGPj1hY7D9YwcdZ4K8bLdx6os2UsZ+tY6JNelJCtaGRonXYpWe4Z6xLHase0brr7m8+Ujm5sVZd4aa13xuTbS+FmoVc2vMjcxKW35RTJbb5IHPb08AAY2xLE/LF7oT+2jP3Ru+Gea8Lyyr1D8tx+T0JOOGfcqRbi5nAhkzWTiCe2X7wP9d+//Ulwz93/3/Bn/x7i3b/5L7jhE+HDvtMeoQc1QN8Q9K2A/Z4Cq9aFBDcbW7C6nGAB2DJT/eQD12KiqLii/arXIJq5o+UtYy3HQN0w2oIsM9RcyCz3qoy2HDVr6K+Z0hIXPJk1NJ1Sz4Lb/bGRnJ0aGSMtx8YtTYb6QnnZljHHo8NNGnFU6UBsQDPaCha4CNSMIbNC3RpMJpW6bY3tUqXsJAftUjHoLOcqss4ni2yXhrkSz1tJYCM0xanSaXlv2585saPRD7ufGB5jMYb+hxfD726G3/28/bOpcFS06D/34tBtbvcjQhe6XY8M89znCRHor6dRpInE9CkEe8Xu0LcT3Pwl+Mp50NwS9md9wdU2/HAQ8Se9Hp76v0MJ2T8d0j5PfQgaa0LHNq8hOz2rB+tbTHDhFdlfQF/dsP8ug/zm4a1hDKkqLa+h2YtT8jwI+miuZAa8C7XYY+KDSztmvY/GuHhmQ+xcRLEGmnmw4I3AY6MtBusZmVG2jOZkRhhshN7rIy3H2HAYoFLPDEN1iyc0ocmdMtzsXRo2MwrXd1vEi5uBTls67BUhNJeXtvUc9hb7pac5PNGEsRldqY4/V2I7pm8l7Pt76L4nt7c5B2j4bhjaNVjvd/xne//xL4Wn/U34Z/nVFWFmQGxRPFu29f92W0ginliejD4Gv/xOsLJ/e1NIQGtugT+9FA5/Aaw5GI45K9ajroddDo0135Hq3OqRje3lgbUwsBIwUKtBbSh2bcsm/HA/7+g9ee/3bm9P+vKePLqvi/amYy1Hf2ZpOo/NhZr4MGK6FYStz1icD5Z5X80ymjsa1iCxJauJceytzRxrglB7Hyx0I0IjCz5qr8pYyzHaCtcmUD43WNpS1n1DJSZNO96NRtEtthViXBHfjjrv8vmUx4QRq3G9EgMv6Iy2z68VPtHX6XJrl5rYBooRw8/8x/BzbGtsKXtLyHFpOdh0N3zptWG/7UNXrQtNadb/Oez7RBh5LLjq+1aGyYY2jige2hMaA9Aag7HH23EiwAysgqHGgvyKScQTS5u8CQ/fBg/8PNxJ7/t7cNjzYHgjfPGVbQu7EOx1G8Lzdj8SnvvOyc+tGh4+b28bXBvOWR8Igt439cCHM05YF0UcnPc0W55mBmNNx2jN0Z+bUsiNCZnYmTWYXCFTmk7x6hioh85Xoy1HIwstUa3GUZxeyYxBTBgN6uI0NCHEzrc0HTa6uwv3vhKni+Xt5ao3uy20vd8aieqs0t5YxPqC3mu0OJSKfgO9hbN8btf+yWLxqRHM0mNZ3/zUBmDP48IDgrdtYHf4k0/CQ7eFLnSP3Rd+tkbD/ofvgG/+r/Hneu674cDfh7uvg6+9tnPfn38O1hw3/78PScQTS4mRTcHC3nnfEH/+16fB724BH83KrC9knh72PNh5f/gfPxxvYU9GIdphpb2tpA+G1sDAziEePrDztFxr63YeYP9dBrlr49ZQruWVZiunmQljLc9ozVFvGUYyi7E+DCAxIV5tCFYyCsNjOX11gyL4OF2sZg2qnkZmGM0dqFLPLHmsa3deyWzodd5Sj6fIMNfy1x1XONaRCa4drj+N6+Maq5TZ5uFY33aoR8GXMh5efVq3W7F8O6fQgZkIRZL5bWMhXb5LGwNrjgqPbsYcrHoCnPHv4bspHwvfTX4Mdn5C2L9ifzj1bzq+S0x94UrfkognFo/b/xPuvb5tZT92Nxz0DHjxF4Iw734UHPD74efuR8OaA9sNH0RCgspk9BLt8GTKQO0dl7c3D6yGnfaGtYeFGNoMrMCXn7Iff/OVm/EaMtCbzjPqlHqeM9wyZNaR2dCoRQhTzrxXXF1xKA1ryEXI8TSsJc+hVhOauSezQst70DCgpBl7m3sN1vlo7lGv+EKAy2Q1ja1S2x3RivfFF+Zw4UHv8H5HAS9qt4uBqYV1Xnz5C0jX29o7y71rg/bOEE5Gd2I+2Xb/gYGBvcOjm9EW1NbA/s/t2DzPDQ87SCKemD9UYcvvQvzpwRiHck144UfD/h+8B+7+YYhf770BNpzTdocDvOCDM3utnoINQV2KbiPx0+V9iJdd9n/ah+18AOyzIXgCZqgoZ2zYm3d8+9ZQ9uUczRzGWjmjRqiZnEwgKxO5FKfhZsTFOHozE2rGYnOhmWlIestDCZo1EixuYxBRvG+LqYon6nsQ7CjmaFWYlZh3Ht+ioN4+xqo1inHbYpcyCc3HExXvqIggWpSLVRLYuv4U4SzSod/d1rVZgqo9Yfx8gVLnU4b+0mSm/6oLOXI9iXhibtj6cBDph2+HE84J//VffS385FPtYwbWhC5LRcD1hR+B/tUh/jwTphLsan/O6qevEO7iOd6FeHvBIU8PNxN25qUhjczymqceyD9+55c4FZreY5s5ViS0XddgObe8kqunv+XJG0otd/S1bOymFmLhCNQk1EhbKzjVtoWroCp4PCLQzLUcWKJKcLP7dmJa+avGcygaRNtLGevWmJUWRDu8fVrcKJTW9XS/xSox8wlJSrUjsz3/9YtPSX0BVTyJeGL65GPwyG9g9f4hY/uWr8A1/xKEe/jh9nFPeB6s2A0O/8PgBt/1CdFF3VWXWUxAmojuxtwzEezied4HRWrbkvEmwMfzxtKr2q5w/EtCOdk28qpTD+Qz197NbzeNkjsYDUVeeCCP9eNjuTLatNRrhoGxUCbWqFlqsZOaGLDxdzISLGhDEPKi65lzPswvj5Z0q6qYGqzn9qbCBi/eR4mudCnfQa9FpXjHu4Qpl6r7q/HzTnSStcT0mY9kvqXn89i+qWVJxBOLRT4WfmaNkFT240vDjOCNd4RSDPXwyitgr+OiRW3hCc+BtU+AXQ9rx5MBDv6DqV9vnFBDbwGYQrCLc5STNpROSSrMWBfF3cHl72o/9/nvgqHZJaNk1nDJy07kOe+7ilYc5el9i5ZzjGaGkWZOzRrqNUufNWRZuwVq0fzFmKIZi6IYvPOhnWtMVnNxvZz6RfvXLZbbVrjiTeVtKK3xqjDHkhi0XWImdP4JZNxCiU64Z/6Zi9dMtxqJ+aBuk4gn5gvvQklV1oDHfws3fjKMAXz0Lnj0Tth8P5z5KTjs+bD1wSDiaw4MJRlHnwlrDoJV+4ZzHfGH4TEZHVbiRBZ1lWmIdfVcpWh3NzMpbMnC6vZtC9y74Dm4thBxA0efPvnvMU0O3m0Fn3zZibz0E9fRcsFabuae4aZns2m7142JxVlaTAsLsXEhxLx916+oMM5F3ZbgySmen6yxRGJhWEANn18RF5FnAe8FLPCvqnpR1/4GcClwPLAROFNV75zPa9quyceCMGd9oZXoyCb4r38I2zbfH38+AKf9PZz06tCD+L/+IczuXbUvHPCU8HPNQeF8+z0Z/vd9vd3UPcUZprZtCquYqYV63Gt1W9iVc0ox77tQPld5rg8+Y9+C1lZ49B74/Hntp7/xvimueWb83kG78J3XncqrP3Ujtz+4pbz03FWuL9mAicR2Sz4XDRKnybyJuIhY4IPAM4B7getF5KuqekvlsJcDj6rqQSLyIuAfgDPn65qWJZsfCI1Ntj4MWx8KyzvvD4c8M1iUn3x+2L71YRh5JDzn914Lz3x76DJ24yVBpFfsERqlrNijnVy2+kD4Pw8Eq7ygEMzY3au0XqdFD4HuXu4l/lVhnspaL03KSsFxYWV737muHjSH5jCMbIbHfgv3XAdXvw8YCU/vWw0DM0ysmwYHrB3iP1//FH581yN88Io7uPGuTTw+2upotpJIJBKzReardEJETgbeoqqnxfU3A6jqOyrHfCce8yMRyYAHgLU6yUWdcMIJesMNN8zNRX7hXLj165UNhZhIux7ZO8pB9cUhIkEgIbimqyJXiIyphRXXqohUJYJYCGc+TJlcVcVGYXHDva/d9sf9I5WNJjzEtGsciusZ9452+2Zn+H8w4eHb+v80nedtyzG9LPcKb3lsGuecO5q556HNo4y1HCO5pxWT1Hq1MgUwxrSXpbpfMKadnFYsFEd3z/QuD+naPpEPZDGqv+aq+cgSrFwLzNF1zWWTlrl8r+bqVNtDlz4R2GUO266KyI2qekKvffPpTt8LuKeyfi9w0kTHqGouIo8Ba4CHWQh+/m/b/lw3yT4F/Ojkz89bU5x/AvEu94/02OjDQ5n8+hJhotGb75n6uLl+2cyw185zb/knEokdk2WR2CYirwJeBbDPPvvM3YlXPQE23TrRq8afE1lxU+03E+xfaneZs72eSZ4/7VP3OHDC53bvkPHLHXfy0SuR9cGqfeCJfwVHv2AJm2uJRCIxfeZTxO8Dqn3q1sVtvY65N7rTVxIS3DpQ1Y8CH4XgTp+zK3zdtXN2qkQikUgkFpr5TIS/HjhYRPYXkTrwIuCrXcd8FXhpXP4T4PLJ4uGJRCKRSCTazJslHmPc5wHfIZSYXayqN4vI24AbVPWrwMeBT4nIHcAjBKFPJBKJRCIxDeY1Jq6q3wS+2bXtwsryKHDGfF5DIpFIJBLbKwvYVyaRSCQSicRckkQ8kUgkEollShLxRCKRSCSWKUnEE4lEIpFYpiQRTyQSiURimZJEPJFIJBKJZcq8DUCZL0TkIeCuOTzlLixUr/btm/Q+zp70Hs6e9B7OnvQezp65fg/3VdW1vXYsOxGfa0TkhommwySmT3ofZ096D2dPeg9nT3oPZ89CvofJnZ5IJBKJxDIliXgikUgkEsuUJOJxOlpi1qT3cfak93D2pPdw9qT3cPYs2Hu4w8fEE4lEIpFYriRLPJFIJBKJZcoOLeIi8iwRuU1E7hCRNy329Sw3RORiEXlQRH6+2NeyXBGRvUXkChG5RURuFpG/XuxrWm6ISJ+IXCci/x3fw7cu9jUtV0TEishPROTri30tyxURuVNEfiYiN4nIDfP+ejuqO11ELPBL4BnAvcD1wFmqesuiXtgyQkROBbYAl6rqkYt9PcsREdkD2ENVfywiK4AbgT9M/4fTR0QEGFTVLSJSA34A/LWqXrPIl7bsEJHXAycAO6nq8xb7epYjInIncIKqLkit/Y5siZ8I3KGqv1bVJvBZ4AWLfE3LClX9PvDIYl/HckZV71fVH8flzcAvgL0W96qWFxrYEldr8bFjWiezQETWAc8F/nWxryUxfXZkEd8LuKeyfi/pyzOxiIjIfsCxwLWLfCnLjugGvgl4EPhPVU3v4cx5D/BGwC/ydSx3FLhMRG4UkVfN94vtyCKeSCwZRGQI+A/gdar6+GJfz3JDVZ2qrgfWASeKSArvzAAReR7woKreuNjXsh3wJFU9Dng28JoYdpw3dmQRvw/Yu7K+Lm5LJBaUGMf9D+AzqvrFxb6e5YyqbgKuAJ61yJey3DgFOD3Gcz8LPE1EPr24l7Q8UdX74s8HgS8RQrfzxo4s4tcDB4vI/iJSB14EfHWRrymxgxGTsj4O/EJV373Y17McEZG1IrIqLvcTklVvXdSLWmao6ptVdZ2q7kf4LrxcVV+8yJe17BCRwZigiogMAs8E5rV6Z4cVcVXNgfOA7xCSif5dVW9e3KtaXojIvwE/Ag4VkXtF5OWLfU3LkFOAvyBYPjfFx3MW+6KWGXsAV4jITwk35/+pqqlEKrEY7Ab8QET+G7gO+Iaqfns+X3CHLTFLJBKJRGK5s8Na4olEIpFILHeSiCcSiUQisUxJIp5IJBKJxDIliXgikUgkEsuUJOKJRCKRSCxTkognEjswIrJKRP4yLu8pIl9Y7GtKJBLTJ5WYJRI7MLFf+9fTFLpEYnmSLfYFJBKJReUi4MA4POR24DBVPVJEzgb+EBgEDgbeCdQJjWnGgOeo6iMiciDwQWAtMAy8UlVTt7REYoFI7vREYsfmTcCv4vCQC7r2HQm8ENgA/D0wrKrHErr0vSQe81Hgtap6PPAG4EMLcdGJRCKQLPFEIjERV8QZ55tF5DHga3H7z4Cj4+S13wM+H1rAA9BY+MtMJHZckognEomJGKss+8q6J3x3GGBTtOITicQikNzpicSOzWZgxbY8Mc49/42InAFhIpuIHDOXF5dIJCYniXgisQOjqhuBq0Xk58A/bcMp/hx4eZzadDPwgrm8vkQiMTmpxCyRSCQSiWVKssQTiUQikVimJBFPJBKJRGKZkkQ8kUgkEollShLxRCKRSCSWKUnEE4lEIpFYpiQRTyQSiURimZJEPJFIJBKJZUoS8UQikUgklin/P3AHvWge/o9xAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 576x720 with 2 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plot_iterations(opt_result)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The initial guess (dashed) and final optimized (solid) control amplitude and resulting dynamics are shown with full opacity, whereas the curves corresponding intermediate iterations are shown with decreasing transparency."
+   ]
+  }
+ ],
+ "metadata": {
+  "hide_input": false,
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.1"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
+  },
+  "varInspector": {
+   "cols": {
+    "lenName": 16,
+    "lenType": 16,
+    "lenVar": 40
+   },
+   "kernels_config": {
+    "python": {
+     "delete_cmd_postfix": "",
+     "delete_cmd_prefix": "del ",
+     "library": "var_list.py",
+     "varRefreshCmd": "print(var_dic_list())"
+    },
+    "r": {
+     "delete_cmd_postfix": ") ",
+     "delete_cmd_prefix": "rm(",
+     "library": "var_list.r",
+     "varRefreshCmd": "cat(var_dic_list()) "
+    }
+   },
+   "types_to_exclude": [
+    "module",
+    "function",
+    "builtin_function_or_method",
+    "instance",
+    "_Feature"
+   ],
+   "window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/src/krotov/__init__.py
+++ b/src/krotov/__init__.py
@@ -45,6 +45,7 @@ from . import (
     mu,
     objectives,
     parallelization,
+    parametrization,
     propagators,
     result,
     second_order,

--- a/src/krotov/mu.py
+++ b/src/krotov/mu.py
@@ -137,4 +137,7 @@ def derivative_wrt_pulse(
             raise NotImplementedError(
                 "Time-dependent collapse operators not implemented"
             )
+    if hasattr(pulses[i_pulse], 'parametrization'):
+        ϵ = pulses[i_pulse][time_index]
+        mu *= pulses[i_pulse].parametrization.derivative(ϵ)
     return mu

--- a/src/krotov/parametrization.py
+++ b/src/krotov/parametrization.py
@@ -1,0 +1,118 @@
+r"""Classes to realized parametrized optimization pulses."""
+import sys
+import warnings
+from abc import ABCMeta, abstractmethod
+
+import numpy as np
+
+
+class ParametrizedFunction(metaclass=ABCMeta):
+    """Wrapped function, adding a `parametrization` attribute."""
+
+    def __init__(self, func, parametrization):
+        self._func = func
+        self.parametrization = parametrization
+
+    def __call__(self, t, args):
+        return self._func(t, args)
+
+
+class ParametrizedArray(np.ndarray):
+    """Wrapped numpy array, adding a `parametrization` attribute."""
+
+    # See https://numpy.org/doc/stable/user/basics.subclassing.html
+    def __new__(cls, input_array, parametrization):
+        obj = np.asarray(input_array).view(cls)
+        obj.parametrization = parametrization
+        if not isinstance(obj.parametrization, Parametrization):
+            raise ValueError(
+                "parametrization must be a Parametrization instance, not %r"
+                % type(parametrization)
+            )
+        return obj
+
+    def __array_finalize__(self, obj):
+        if obj is None:
+            return
+        self.parametrization = getattr(obj, 'parametrization', None)
+
+
+class Parametrization(metaclass=ABCMeta):
+    """Abstract base class for a parametrizations."""
+
+    @abstractmethod
+    def parametrize(self, eps_val):
+        return NotImplementedError
+
+    @abstractmethod
+    def unparametrize(self, u_val):
+        return NotImplementedError
+
+    @abstractmethod
+    def derivative(self):
+        return NotImplementedError
+
+
+class TanhParametrization(Parametrization):
+    def __init__(self, *, eps_max, eps_min):
+        self.eps_max = eps_max
+        self.eps_min = eps_min
+
+    def parametrize(self, eps_val):
+        ϵ_max = self.eps_max
+        ϵ_min = self.eps_min
+        ϵ = eps_val
+        if ϵ >= ϵ_max or ϵ <= ϵ_min:
+            warnings.warn(
+                "Pulse value %r out of range (%r, %r) for %s. "
+                "Value will be clipped."
+                % (ϵ, ϵ_min, ϵ_max, self.__class__.__name__)
+            )
+        Δ = ϵ_max - ϵ_min
+        a = np.clip(
+            2 * ϵ / Δ - (ϵ_max + ϵ_min) / Δ,
+            -1 + sys.float_info.epsilon,
+            1 - sys.float_info.epsilon,
+        )
+        u = np.arctanh(a)  # -18.4 < u < 18.4
+        return u
+
+    def unparametrize(self, u_val):
+        ϵ_max = self.eps_max
+        ϵ_min = self.eps_min
+        u = u_val
+        cp = 0.5 * (ϵ_max + ϵ_min)
+        cm = 0.5 * (ϵ_max - ϵ_min)
+        ϵ = cm * np.tanh(u) + cp
+        return ϵ
+
+    def derivative(self, eps_val):
+        ϵ_max = self.eps_max
+        ϵ_min = self.eps_min
+        ϵ = eps_val
+        Δ = ϵ_max - ϵ_min
+        a = np.clip(
+            2 * ϵ / Δ - (ϵ_max + ϵ_min) / Δ,
+            -1 + sys.float_info.epsilon,
+            1 - sys.float_info.epsilon,
+        )
+        u = np.arctanh(a)
+        return 0.5 * Δ / np.cosh(u) ** 2
+
+
+class SquareParametrization(Parametrization):
+    def parametrize(self, eps_val):
+        if eps_val < 0:
+            warnings.warn(
+                "Pulse value %r < 0 out of range for %s. Clip to 0."
+                % (eps_val, self.__class__.__name__)
+            )
+            eps_val = 0
+        return np.sqrt(eps_val)
+
+    def unparametrize(self, u_val):
+        return u_val ** 2
+
+    def derivative(self, eps_val):
+        u = self.parametrize(eps_val)
+        return 2 * u


### PR DESCRIPTION
This adds support for parametrized pulses by attaching an optional 'parametrization' attribute to control-functions and pulse arrays. The parametrization object stored in that attribute contains information for converting ϵ⟷u and calculating the derivative ∂ϵ/∂u. These are automatically taking into account when calculating the pulse updates (μ = (∂Ĥ/∂ϵ)⋅(∂ϵ/∂u) for an Ĥ that is linear in ϵ).

Thus, all internal storage is for the physical pulse values ϵ(t), and any conversion to u(t) is done on the fly as necessary. This ensures that everything stays 100% compatible with QuTiP, but adds a small overhead from the ϵ⟷u conversions compared to the "hacky" solution discussed in https://github.com/qucontrol/krotov/issues/23#issuecomment-850887732. The latter could still be used by an advanced user when performance is more critical than clarity.

Closes #23