### PR TITLE
Clarify notation for Wirtinger derivative

### DIFF
--- a/docs/07_krotovs_method.rst
+++ b/docs/07_krotovs_method.rst
@@ -415,6 +415,18 @@ a single state-to-state transition (:math:`N=1`),
 cf. :func:`krotov.functionals.chis_ss` and the :mod:`krotov.functionals` module
 in general.
 
+More precisely, the right hand side of Eq. :eq:`chi_boundary` is a `Wirtinger derivative`_. That is, if the j'th component of $\ket{\phi_k(T)}$ is the complex number $x_j + \ii y_j$ then the j'th component of $\ket{\chi_k(T)}$ is
+
+.. math::
+   :label: wirtinger_deriv
+
+    \chi_j = - \frac{1}{2} \left(\frac{\partial J_T}{\partial x_j} + \ii \frac{\partial J_T}{\partial y_j} \right)\,.
+
+Generally, though, the state $\ket{\chi_k(T)}$ can be calculated simply by fully expanding $J_T$ and treating co-states as independent variables, as in the example for $J_{T,ss}$ above. Hence the intuitive notation in Eq. :eq:`chi_boundary`.
+
+
+.. _Wirtinger derivative: https://en.wikipedia.org/wiki/Wirtinger_derivatives
+
 
 
 .. _SecondOrderUpdate:
@@ -535,7 +547,7 @@ control, so that :math:`\partial \Op{H} / \partial \epsilon(t)` is not
 time-dependent. The scheme proceeds as follows:
 
 #. Construct the states :math:`\{\ket{\chi^{(i-1)}_k(T)}\}` according to
-   Eq. :eq:`chi_boundary`. For most functionals,
+   Wirtinger derivative in Eq. :eq:`chi_boundary`. For most functionals,
    specifically any that are more than linear in the overlaps
    :math:`\tau_k` defined in Eq. :eq:`tauk`, the states
    :math:`\{\ket{\chi^{(i-1)}_k(T)}\}` depend on the states

--- a/src/krotov/functionals.py
+++ b/src/krotov/functionals.py
@@ -39,15 +39,18 @@ for functionals defined in Hilbert space, or
 
 in Liouville space, using the abstract
 Hilbert-Schmidt notation :math:`\langle\!\langle a \vert b \rangle\!\rangle
-\equiv \tr[a^\dagger b]`.
-Passing a specific `chi_constructor` results in the minimization of the final
-time functional from which that `chi_constructor` was derived.
+\equiv \tr[a^\dagger b]`. The notation on the right hand side is a `Wirtinger
+derivative`_, see Eq. :eq:`wirtinger_deriv`. Passing a specific
+`chi_constructor` results in the minimization of the final time functional from
+which that `chi_constructor` was derived.
 
 The functions in this module that evaluate functionals are intended for use
 inside a function that is passed as an `info_hook` to :func:`.optimize_pulses`.
 Thus, they calculate $J_T$ from the same keyword arguments as the `info_hook`.
 The values for $J_T$ may be used in a convergence analysis, see
 :mod:`krotov.convergence`.
+
+.. _Wirtinger derivative: https://en.wikipedia.org/wiki/Wirtinger_derivatives
 """
 import logging
 


### PR DESCRIPTION
I recently had reason to look a bit more rigorously at the definition of the boundary condition for Krotov's backward propagation. We've always treated this in a bit of a handwaving manner, but it seems to me that derivative with respect to the bra of the forward-propagated state is properly known as a [Wirtinger derivative](https://en.wikipedia.org/wiki/Wirtinger_derivatives).

It's probably a good idea to include the rigorous definition in the documentation, for people who don't appreciate the handwaving approach or for more complicated functionals where things might not be so obvious.

@danielreich Can you review this?