### PR TITLE
Limit compatibility with qutip to < 5.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ requirements = [
     'glom',
     'numpy',
     'scipy',
-    'qutip>=4.3.1',
+    'qutip>=4.3.1,<5.0',
     'threadpoolctl',
     'grapheme',
 ]


### PR DESCRIPTION
`krotov` currently does not upper-bound the dependency on `qutip`, but is not compatible with the newest (breaking) 5.0 release.